### PR TITLE
Dependency clean-up

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,8 +17,7 @@ bench = false
 math = { path = "../math", package = "winter-math" }
 crypto = { path = "../crypto", package = "winter-crypto" }
 fri = { path = "../fri", package = "winter-fri" }
-displaydoc = "0.2"
-rand = "0.8"
-
 serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
+
+[dev-dependencies]
+rand = "0.8"

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -3,20 +3,37 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use displaydoc::Display;
-use thiserror::Error;
+use core::fmt;
 
+// PROVER ERROR
+// ================================================================================================
 /// Represents an error thrown by the prover during an execution of the protocol
-#[derive(Debug, Display, Error)]
+#[derive(Debug, PartialEq)]
 pub enum ProverError {
-    /// A transition constraint was not satisfied at a certain step {0}
+    /// A transition constraint was not satisfied at step {0}
     UnsatisfiedTransitionConstraintError(usize),
-    /// The constraint polynomial's components do not all have the same degree, expected {0} but found {1}
+    /// The constraint polynomial's components do not all have the same degree; expected {0}, but was {1}
     MismatchedConstraintPolynomialDegree(usize, usize),
 }
 
+impl fmt::Display for ProverError {
+    #[rustfmt::skip]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsatisfiedTransitionConstraintError(step) => {
+                write!(f, "a transition constraint was not satisfied at step {}", step)
+            }
+            Self::MismatchedConstraintPolynomialDegree(expected, actual) => {
+                write!(f, "the constraint polynomial's components do not all have the same degree; expected {}, but was {}", expected, actual)
+            }
+        }
+    }
+}
+
+// VERIFIER ERROR
+// ================================================================================================
 /// Represents an error thrown by the verifier during an execution of the protocol
-#[derive(Debug, Display, Error)]
+#[derive(Debug, PartialEq)]
 pub enum VerifierError {
     /// Verification of low-degree proof failed: {0}
     FriVerificationFailed(fri::VerifierError),
@@ -36,15 +53,68 @@ pub enum VerifierError {
     ComputationContextDeserializationFailed,
 }
 
+impl fmt::Display for VerifierError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FriVerificationFailed(err) => {
+                write!(f, "verification of low-degree proof failed: {}", err)
+            }
+            Self::TraceQueryDoesNotMatchCommitment => {
+                write!(f, "trace query did not match the commitment")
+            }
+            Self::TraceQueryDeserializationFailed => {
+                write!(f, "trace query deserialization failed")
+            }
+            Self::ConstraintQueryDoesNotMatchCommitment => {
+                write!(f, "constraint query did not match the commitment")
+            }
+            Self::ConstraintQueryDeserializationFailed => {
+                write!(f, "constraint query deserialization failed")
+            }
+            Self::QuerySeedProofOfWorkVerificationFailed => {
+                write!(f, "query seed proof-of-work verification failed")
+            }
+            Self::OodFrameDeserializationFailed => {
+                write!(f, "out-of-domain frame deserialization failed")
+            }
+            Self::ComputationContextDeserializationFailed => {
+                write!(f, "computation context deserialization failed")
+            }
+        }
+    }
+}
+
+// ASSERTION ERROR
+// ================================================================================================
 /// Represents an error thrown during evaluation
-#[derive(Debug, Display, Error, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum AssertionError {
-    /// expected trace width to be at least {0}, but was {1}
+    /// Expected trace width to be at least {0}, but was {1}
     TraceWidthTooShort(usize, usize),
-    /// expected trace length to be a power of two, but was {0}
+    /// Expected trace length to be a power of two, but was {0}
     TraceLengthNotPowerOfTwo(usize),
-    /// expected trace length to be at least {0}, but was {1}
+    /// Expected trace length to be at least {0}, but was {1}
     TraceLengthTooShort(usize, usize),
-    /// expected trace length to be exactly {0}, but was {1}
+    /// Expected trace length to be exactly {0}, but was {1}
     TraceLengthNotExact(usize, usize),
+}
+
+impl fmt::Display for AssertionError {
+    #[rustfmt::skip]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TraceWidthTooShort(expected, actual) => {
+                write!(f, "expected trace width to be at least {}, but was {}", expected, actual)
+            }
+            Self::TraceLengthNotPowerOfTwo(actual) => {
+                write!(f, "expected trace length to be a power of two, but was {}", actual)
+            }
+            Self::TraceLengthTooShort(expected, actual) => {
+                write!(f, "expected trace length to be at least {}, but was {}", expected, actual)
+            }
+            Self::TraceLengthNotExact(expected, actual) => {
+                write!(f, "expected trace length to be exactly {}, but was {}", expected, actual)
+            }
+        }
+    }
 }

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -29,9 +29,8 @@ concurrent = ["rayon", "crypto/concurrent"]
 utils = { path = "../utils", package = "winter-utils" }
 math = { path = "../math", package = "winter-math" }
 crypto = { path = "../crypto", package = "winter-crypto" }
-thiserror = "1.0"
-serde = { version = "1.0", features = ["derive"] }
 rayon = { version = "1.5", optional = true }
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/fri/src/verifier/errors.rs
+++ b/fri/src/verifier/errors.rs
@@ -3,31 +3,56 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use thiserror::Error;
+use core::fmt;
 
-#[derive(Error, Debug)]
+#[derive(Debug, PartialEq)]
 pub enum VerifierError {
-    #[error("FRI queries did not match the commitment at layer {0}")]
+    /// FRI queries did not match the commitment at layer {0}
     LayerCommitmentMismatch(usize),
-
-    #[error("FRI queries at layer {0} could not be deserialized: {1}")]
+    /// FRI queries at layer {} could not be deserialized: {0}
     LayerDeserializationError(usize, String),
-
-    #[error("FRI evaluations did not match query values at depth {0}")]
+    /// FRI evaluations did not match query values at depth {0}
     LayerValuesNotConsistent(usize),
-
-    #[error("FRI remainder did not match the commitment")]
+    /// FRI remainder did not match the commitment
     RemainderCommitmentMismatch,
-
-    #[error("FRI remainder could not be deserialized: {0}")]
+    /// FRI remainder could not be deserialized: {0}
     RemainderDeserializationError(String),
-
-    #[error("FRI remainder values are inconsistent with values of the last column")]
+    /// FRI remainder values are inconsistent with values of the last column
     RemainderValuesNotConsistent,
-
-    #[error("FRI remainder degree is greater than number of remainder values")]
+    /// FRI remainder expected degree is greater than number of remainder values
     RemainderDegreeNotValid,
-
-    #[error("FRI remainder is not a valid degree {0} polynomial")]
+    /// "FRI remainder is not a valid degree {0} polynomial
     RemainderDegreeMismatch(usize),
+}
+
+impl fmt::Display for VerifierError {
+    #[rustfmt::skip]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LayerCommitmentMismatch(layer) => {
+                write!(f, "FRI queries did not match the commitment at layer {}", layer)
+            }
+            Self::LayerDeserializationError(layer, err_msg) => {
+                write!(f, "FRI queries at layer {} could not be deserialized: {}", layer, err_msg)
+            }
+            Self::LayerValuesNotConsistent(layer) => {
+                write!(f, "FRI evaluations did not match query values at depth {}", layer)
+            }
+            Self::RemainderCommitmentMismatch => {
+                write!(f, "FRI remainder did not match the commitment")
+            }
+            Self::RemainderDeserializationError(err_msg) => {
+                write!(f, "FRI remainder could not be deserialized: {}", err_msg)
+            }
+            Self::RemainderValuesNotConsistent => {
+                write!(f, "FRI remainder values are inconsistent with values of the last column")
+            }
+            Self::RemainderDegreeNotValid => {
+                write!(f, "FRI remainder expected degree is greater than number of remainder values")
+            }
+            Self::RemainderDegreeMismatch(degree) => {
+                write!(f, "FRI remainder is not a valid degree {} polynomial", degree)
+            }
+        }
+    }
 }

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -30,10 +30,9 @@ concurrent = ["rayon"]
 
 [dependencies]
 utils = { path = "../utils", package = "winter-utils" }
-rand = "0.8"
-thiserror = "1.0"
-serde = { version = "1.0", features = ["derive"] }
 rayon = { version = "1.5", optional = true }
+serde = { version = "1.0", features = ["derive"] }
+rand = "0.8"
 
 
 [dev-dependencies]

--- a/math/src/errors.rs
+++ b/math/src/errors.rs
@@ -3,34 +3,72 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use thiserror::Error;
+use core::fmt;
 
-#[derive(Error, Debug, PartialEq)]
+// SERIALIZATION ERROR
+// ================================================================================================
+#[derive(Debug, PartialEq)]
 pub enum SerializationError {
-    #[error("destination must be at least {0} elements long, but was {1}")]
+    /// Destination must be at least {0} elements long, but was {1}
     DestinationTooSmall(usize, usize),
-
-    #[error("failed to read field element from bytes at position {0}")]
+    /// Failed to read field element from bytes at position {0}
     FailedToReadElement(usize),
-
-    #[error("number of bytes ({0}) does not divide into whole number of field elements")]
+    /// Number of bytes ({0}) does not divide into whole number of field elements
     NotEnoughBytesForWholeElements(usize),
-
-    #[error("slice memory alignment is not valid for this field element type")]
+    /// Slice memory alignment is not valid for this field element type
     InvalidMemoryAlignment,
 }
 
-#[derive(Error, Debug, PartialEq)]
+impl fmt::Display for SerializationError {
+    #[rustfmt::skip]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DestinationTooSmall(expected, actual) => {
+                write!(f, "destination must be at least {} elements long, but was {}", expected, actual)
+            }
+            Self::FailedToReadElement(position) => {
+                write!(f, "failed to read field element from bytes at position {}", position)
+            }
+            Self::NotEnoughBytesForWholeElements(num_bytes) => {
+                write!(f, "number of bytes ({}) does not divide into whole number of field elements", num_bytes)
+            }
+            Self::InvalidMemoryAlignment => {
+                write!(f, "slice memory alignment is not valid for this field element type")
+            }
+        }
+    }
+}
+
+// ELEMENT DECODING ERROR
+// ================================================================================================
+#[derive(Debug, PartialEq)]
 pub enum ElementDecodingError {
-    #[error("not enough bytes for a full field element; expected {0} bytes, but was {1} bytes")]
+    /// Not enough bytes for a full field element; expected {0} bytes, but was {1} bytes
     NotEnoughBytes(usize, usize),
-
-    #[error("too many bytes for a field element; expected {0} bytes, but was {1} bytes")]
+    /// Too many bytes for a field element; expected {0} bytes, but was {1} bytes
     TooManyBytes(usize, usize),
-
-    #[error("invalid field element: value {0} is greater than or equal to the field modulus")]
+    /// Invalid field element: value {0} is greater than or equal to the field modulus
     ValueTooLarger(String),
-
-    #[error("{0}")]
+    /// Unknown error: {0}
     UnknownError(String),
+}
+
+impl fmt::Display for ElementDecodingError {
+    #[rustfmt::skip]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotEnoughBytes(expected, actual) => {
+                write!(f, "not enough bytes for a full field element; expected {} bytes, but was {} bytes", expected, actual)
+            }
+            Self::TooManyBytes(expected, actual) => {
+                write!(f, "too many bytes for a field element; expected {} bytes, but was {} bytes", expected, actual)
+            }
+            Self::ValueTooLarger(value) => {
+                write!(f, "invalid field element: value {} is greater than or equal to the field modulus", value)
+            }
+            Self::UnknownError(err_msg) => {
+                write!(f, "unknown error: {}", err_msg)
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR removes dependency on `thiserror` and `displaydoc` crates. The primary motivation is to reduce use of std-based dependencies and the number of dependences overall.