### PR TITLE
Queries serialization improvements

### DIFF
--- a/common/src/proof.rs
+++ b/common/src/proof.rs
@@ -51,8 +51,8 @@ pub struct Commitments {
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Queries {
-    pub paths: Vec<Vec<[u8; 32]>>,
-    pub values: Vec<Vec<u8>>,
+    pub paths: Vec<u8>,
+    pub values: Vec<u8>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -117,40 +117,85 @@ impl StarkProof {
 // ================================================================================================
 
 impl Queries {
-    /// Returns a set of queries constructed from a batch Merkle proof and corresponding values.
-    pub fn new<E: FieldElement>(merkle_proof: BatchMerkleProof, values: Vec<Vec<E>>) -> Self {
+    /// Returns a set of queries constructed from a batch Merkle proof and corresponding elements.
+    pub fn new<E: FieldElement>(merkle_proof: BatchMerkleProof, query_values: Vec<Vec<E>>) -> Self {
+        assert!(!query_values.is_empty(), "query values cannot be empty");
+        let elements_per_query = query_values[0].len();
+        assert!(
+            elements_per_query != 0,
+            "a query must contain at least one value"
+        );
+
         // TODO: add debug check that values actually hash into the leaf nodes of the batch proof
-        Queries {
-            paths: merkle_proof.nodes,
-            values: values
-                .into_iter()
-                .map(|v| E::elements_as_bytes(&v).to_vec())
-                .collect(),
+
+        // concatenate all elements together into a single vector of bytes
+        let num_queries = query_values.len();
+        let mut values = Vec::with_capacity(num_queries * elements_per_query * E::ELEMENT_BYTES);
+        for elements in query_values.iter() {
+            assert_eq!(
+                elements.len(),
+                elements_per_query,
+                "all queries must contain the same number of values"
+            );
+            values.extend_from_slice(E::elements_as_bytes(elements));
         }
+
+        // serialize internal nodes of the batch Merkle proof; we care about internal nodes only
+        // because leaf nodes can be reconstructed from hashes of query values
+        let paths = merkle_proof.serialize_nodes();
+
+        Queries { paths, values }
     }
 
-    /// Convert a set of queries into a batch Merkle proof and corresponding values.
+    /// Convert a set of queries into a batch Merkle proof and corresponding query values.
     pub fn deserialize<H: Hasher, E: FieldElement>(
         self,
-        num_leaves: usize,
-        _elements_per_query: usize,
+        domain_size: usize,
+        elements_per_query: usize,
     ) -> Result<(BatchMerkleProof, Vec<Vec<E>>), SerializationError> {
+        assert!(
+            domain_size.is_power_of_two(),
+            "domain size must be a power of two"
+        );
+        assert!(
+            elements_per_query >= 1,
+            "a query must contain at least one element"
+        );
         let hash_fn = H::hash_fn();
-        let mut hashed_values = vec![[0u8; 32]; self.values.len()];
-        let mut query_elements = Vec::new();
-        for (query_values, query_hash) in self.values.iter().zip(hashed_values.iter_mut()) {
-            hash_fn(query_values, query_hash);
-            let x = read_elements_into_vec::<E>(query_values)?;
-            query_elements.push(x);
+
+        // make sure we have enough bytes to read the expected number of queries
+        let num_query_bytes = E::ELEMENT_BYTES * elements_per_query;
+        // TODO: pass num_queries as a parameter into this function and change the check to be
+        // num_queries * num_query_bytes == self.values.len()
+        let num_queries = self.values.len() / num_query_bytes;
+        if self.values.len() % num_query_bytes != 0 {
+            let expected_bytes = (num_queries + 1) * num_query_bytes;
+            return Err(SerializationError::WrongNumberOfBytes(
+                expected_bytes,
+                self.values.len(),
+            ));
         }
 
-        let merkle_proof = BatchMerkleProof {
-            nodes: self.paths,
-            values: hashed_values,
-            depth: log2(num_leaves) as u8,
-        };
+        let mut hashed_queries = vec![[0u8; 32]; num_queries];
+        let mut query_values = Vec::with_capacity(num_queries);
 
-        Ok((merkle_proof, query_elements))
+        // read bytes corresponding to each query, convert them into field elements,
+        // and also hash them to build leaf nodes of the batch Merkle proof
+        for (query_bytes, query_hash) in self
+            .values
+            .chunks(num_query_bytes)
+            .zip(hashed_queries.iter_mut())
+        {
+            hash_fn(query_bytes, query_hash);
+            let elements = read_elements_into_vec::<E>(query_bytes)?;
+            query_values.push(elements);
+        }
+
+        // build batch Merkle proof
+        let tree_depth = log2(domain_size) as u8;
+        let merkle_proof = BatchMerkleProof::deserialize(&self.paths, hashed_queries, tree_depth);
+
+        Ok((merkle_proof, query_values))
     }
 }
 

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
         now.elapsed().as_millis()
     );
     let proof_bytes = bincode::serialize(&proof).unwrap();
-    debug!("Proof size: {} KB", proof_bytes.len() / 1024);
+    debug!("Proof size: {:.1} KB", proof_bytes.len() as f64 / 1024f64);
     debug!("Proof security: {} bits", proof.security_level(true));
 
     // verify the proof

--- a/math/src/errors.rs
+++ b/math/src/errors.rs
@@ -11,6 +11,8 @@ use core::fmt;
 pub enum SerializationError {
     /// Destination must be at least {0} elements long, but was {1}
     DestinationTooSmall(usize, usize),
+    /// Expected source to contain exactly {0} bytes, but was {1}
+    WrongNumberOfBytes(usize, usize),
     /// Failed to read field element from bytes at position {0}
     FailedToReadElement(usize),
     /// Number of bytes ({0}) does not divide into whole number of field elements
@@ -25,6 +27,9 @@ impl fmt::Display for SerializationError {
         match self {
             Self::DestinationTooSmall(expected, actual) => {
                 write!(f, "destination must be at least {} elements long, but was {}", expected, actual)
+            }
+            Self::WrongNumberOfBytes(expected, actual) => {
+                write!(f, "expected source to contain exactly {} bytes, but was {}", expected, actual)
             }
             Self::FailedToReadElement(position) => {
                 write!(f, "failed to read field element from bytes at position {}", position)


### PR DESCRIPTION
This PR addresses #6 and also improves queries serialization/deserialization overall. Specifically:

- [x] Implement deserialization of query bytes directly into field elements
- [x] Implement flat serialization of query values and Merkle paths (for trace and constraint queries only)

The overall impact of this PR is ~1% reduction in proof sizes, but it also lays groundwork for switching over to new Merkle tree implementation.