### PR TITLE
Fri proof serialization improvements

### DIFF
--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -35,6 +35,8 @@ impl fmt::Display for ProverError {
 /// Represents an error thrown by the verifier during an execution of the protocol
 #[derive(Debug, PartialEq)]
 pub enum VerifierError {
+    /// Proof deserialization failed: {0}
+    ProofDeserializationError(String),
     /// Verification of low-degree proof failed: {0}
     FriVerificationFailed(fri::VerifierError),
     /// Trace query did not match the commitment
@@ -56,6 +58,9 @@ pub enum VerifierError {
 impl fmt::Display for VerifierError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::ProofDeserializationError(msg) => {
+                write!(f, "proof deserialization failed: {}", msg)
+            }
             Self::FriVerificationFailed(err) => {
                 write!(f, "verification of low-degree proof failed: {}", err)
             }

--- a/fri/src/errors.rs
+++ b/fri/src/errors.rs
@@ -5,18 +5,17 @@
 
 use core::fmt;
 
+// VERIFIER ERROR
+// ================================================================================================
+
 #[derive(Debug, PartialEq)]
 pub enum VerifierError {
     /// FRI queries did not match the commitment at layer {0}
     LayerCommitmentMismatch(usize),
-    /// FRI queries at layer {} could not be deserialized: {0}
-    LayerDeserializationError(usize, String),
     /// FRI evaluations did not match query values at depth {0}
     LayerValuesNotConsistent(usize),
     /// FRI remainder did not match the commitment
     RemainderCommitmentMismatch,
-    /// FRI remainder could not be deserialized: {0}
-    RemainderDeserializationError(String),
     /// FRI remainder values are inconsistent with values of the last column
     RemainderValuesNotConsistent,
     /// FRI remainder expected degree is greater than number of remainder values
@@ -32,17 +31,11 @@ impl fmt::Display for VerifierError {
             Self::LayerCommitmentMismatch(layer) => {
                 write!(f, "FRI queries did not match the commitment at layer {}", layer)
             }
-            Self::LayerDeserializationError(layer, err_msg) => {
-                write!(f, "FRI queries at layer {} could not be deserialized: {}", layer, err_msg)
-            }
             Self::LayerValuesNotConsistent(layer) => {
                 write!(f, "FRI evaluations did not match query values at depth {}", layer)
             }
             Self::RemainderCommitmentMismatch => {
                 write!(f, "FRI remainder did not match the commitment")
-            }
-            Self::RemainderDeserializationError(err_msg) => {
-                write!(f, "FRI remainder could not be deserialized: {}", err_msg)
             }
             Self::RemainderValuesNotConsistent => {
                 write!(f, "FRI remainder values are inconsistent with values of the last column")
@@ -52,6 +45,36 @@ impl fmt::Display for VerifierError {
             }
             Self::RemainderDegreeMismatch(degree) => {
                 write!(f, "FRI remainder is not a valid degree {} polynomial", degree)
+            }
+        }
+    }
+}
+
+// PROOF SERIALIZATION ERROR
+// ================================================================================================
+
+#[derive(Debug, PartialEq)]
+pub enum ProofSerializationError {
+    /// FRI queries at layer {} could not be deserialized: {0}
+    LayerDeserializationError(usize, String),
+    /// FRI remainder domain size must be {0}, but was {1}
+    InvalidRemainderDomain(usize, usize),
+    /// FRI remainder could not be deserialized: {0}
+    RemainderDeserializationError(String),
+}
+
+impl fmt::Display for ProofSerializationError {
+    #[rustfmt::skip]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LayerDeserializationError(layer, err_msg) => {
+                write!(f, "FRI queries at layer {} could not be deserialized: {}", layer, err_msg)
+            }
+            Self::InvalidRemainderDomain(num_remainder_elements, domain_size) => {
+                write!(f, "FRI remainder domain size must be {}, but was {}", num_remainder_elements, domain_size)
+            }
+            Self::RemainderDeserializationError(err_msg) => {
+                write!(f, "FRI remainder could not be deserialized: {}", err_msg)
             }
         }
     }

--- a/fri/src/lib.rs
+++ b/fri/src/lib.rs
@@ -7,12 +7,13 @@ mod prover;
 pub use prover::{DefaultProverChannel, FriProver, ProverChannel};
 
 mod verifier;
-pub use verifier::{
-    verify, DefaultVerifierChannel, VerifierChannel, VerifierContext, VerifierError,
-};
+pub use verifier::{verify, DefaultVerifierChannel, VerifierChannel, VerifierContext};
 
 mod options;
 pub use options::FriOptions;
+
+mod errors;
+pub use errors::{ProofSerializationError, VerifierError};
 
 mod proof;
 pub use proof::{FriProof, FriProofLayer};

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -3,18 +3,180 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use crate::ProofSerializationError;
+use crypto::{BatchMerkleProof, Hasher};
+use math::{
+    field::FieldElement,
+    utils::{log2, read_elements_into_vec},
+};
+
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct FriProofLayer {
-    pub values: Vec<Vec<u8>>,
-    pub paths: Vec<Vec<[u8; 32]>>,
-    pub depth: u8,
-}
+// FRI PROOF
+// ================================================================================================
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FriProof {
-    pub layers: Vec<FriProofLayer>,
-    pub rem_values: Vec<u8>,
-    pub partitioned: bool,
+    layers: Vec<FriProofLayer>,
+    remainder: Vec<u8>,
+    partitioned: bool,
+}
+
+impl FriProof {
+    /// Creates a new FRI proof from the provided layers and remainder values.
+    pub fn new<E: FieldElement>(
+        layers: Vec<FriProofLayer>,
+        remainder: Vec<E>,
+        partitioned: bool,
+    ) -> Self {
+        FriProof {
+            layers,
+            remainder: E::elements_as_bytes(&remainder).to_vec(),
+            partitioned,
+        }
+    }
+
+    /// Returns true if this proof was generated in multiple partitions.
+    pub fn is_partitioned(&self) -> bool {
+        self.partitioned
+    }
+
+    // PARSING
+    // --------------------------------------------------------------------------------------------
+
+    /// Decomposes this proof into vectors of query values for each FRI layer and corresponding
+    /// Merkle paths for each query (grouped into batch Merkle proofs)
+    pub fn parse_layers<H: Hasher, E: FieldElement>(
+        self,
+        mut domain_size: usize,
+        folding_factor: usize,
+    ) -> Result<(Vec<Vec<E>>, Vec<BatchMerkleProof>), ProofSerializationError> {
+        assert!(
+            domain_size.is_power_of_two(),
+            "domain size must be a power of two"
+        );
+        assert!(
+            folding_factor.is_power_of_two(),
+            "folding factor must be a power of two"
+        );
+
+        // cache the number of remainder elements here for comparison later
+        let num_remainder_elements = self.remainder.len() / E::ELEMENT_BYTES;
+
+        let mut layer_proofs = Vec::new();
+        let mut layer_queries = Vec::new();
+
+        // parse all layers
+        for (i, layer) in self.layers.into_iter().enumerate() {
+            domain_size /= folding_factor;
+            let (qv, mp) = layer.parse::<H, E>(i, domain_size, folding_factor)?;
+            layer_proofs.push(mp);
+            layer_queries.push(qv);
+        }
+
+        // make sure the remaining domain size matches remainder length
+        if domain_size != num_remainder_elements {
+            return Err(ProofSerializationError::InvalidRemainderDomain(
+                num_remainder_elements,
+                domain_size,
+            ));
+        }
+
+        Ok((layer_queries, layer_proofs))
+    }
+
+    /// Returns a vector of remainder values (last FRI layer)
+    pub fn parse_remainder<E: FieldElement>(&self) -> Result<Vec<E>, ProofSerializationError> {
+        let remainder = read_elements_into_vec(&self.remainder).map_err(|err| {
+            ProofSerializationError::RemainderDeserializationError(err.to_string())
+        })?;
+        Ok(remainder)
+    }
+}
+
+// FRI PROOF LAYER
+// ================================================================================================
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FriProofLayer {
+    values: Vec<u8>,
+    paths: Vec<u8>,
+}
+
+impl FriProofLayer {
+    /// Creates a new proof layer from the specified query values and the corresponding Merkle
+    /// paths aggregated into a single batch Merkle proof.
+    pub fn new<E: FieldElement, const N: usize>(
+        query_values: Vec<[E; N]>,
+        merkle_proof: BatchMerkleProof,
+    ) -> Self {
+        assert!(!query_values.is_empty(), "query values cannot be empty");
+
+        // TODO: add debug check that values actually hash into the leaf nodes of the batch proof
+
+        // concatenate all query values together into a single vector of bytes
+        let mut values = Vec::with_capacity(query_values.len() * N * E::ELEMENT_BYTES);
+        for elements in query_values.iter() {
+            values.extend_from_slice(E::elements_as_bytes(elements));
+        }
+
+        // concatenate all internal proof nodes together into a single vector of bytes; we care
+        // about internal nodes only because leaf nodes can be reconstructed from hashes of query
+        // values
+        let paths = merkle_proof.serialize_nodes();
+
+        FriProofLayer { values, paths }
+    }
+
+    /// Decomposes this layer into a combination of query values and corresponding Merkle
+    /// paths (grouped together into a single batch Merkle proof).
+    pub fn parse<H: Hasher, E: FieldElement>(
+        self,
+        layer_depth: usize,
+        domain_size: usize,
+        folding_factor: usize,
+    ) -> Result<(Vec<E>, BatchMerkleProof), ProofSerializationError> {
+        let hash_fn = H::hash_fn();
+
+        // these will fail only if the struct was constructed incorrectly
+        assert!(!self.values.is_empty(), "empty values vector");
+        assert!(!self.paths.is_empty(), "empty paths vector");
+
+        // make sure the number of value bytes can be parsed into a whole number of queries
+        let num_query_bytes = E::ELEMENT_BYTES * folding_factor;
+        if self.values.len() % num_query_bytes != 0 {
+            return Err(ProofSerializationError::LayerDeserializationError(
+                layer_depth,
+                format!(
+                    "number of value bytes ({}) does not divide into whole number of queries",
+                    self.values.len()
+                ),
+            ));
+        }
+
+        let num_queries = self.values.len() / num_query_bytes;
+        let mut hashed_queries = vec![[0u8; 32]; num_queries];
+        let mut query_values = Vec::with_capacity(num_queries * folding_factor);
+
+        // read bytes corresponding to each query, convert them into field elements,
+        // and also hash them to build leaf nodes of the batch Merkle proof
+        for (query_bytes, query_hash) in self
+            .values
+            .chunks(num_query_bytes)
+            .zip(hashed_queries.iter_mut())
+        {
+            hash_fn(query_bytes, query_hash);
+            query_values.append(
+                &mut read_elements_into_vec::<E>(query_bytes).map_err(|err| {
+                    ProofSerializationError::LayerDeserializationError(layer_depth, err.to_string())
+                })?,
+            );
+        }
+
+        // build batch Merkle proof
+        let tree_depth = log2(domain_size) as u8;
+        let merkle_proof = BatchMerkleProof::deserialize(&self.paths, hashed_queries, tree_depth);
+
+        Ok((query_values, merkle_proof))
+    }
 }

--- a/fri/src/prover/monolith/mod.rs
+++ b/fri/src/prover/monolith/mod.rs
@@ -149,14 +149,7 @@ where
                 queried_values.push(self.layers[i].evaluations[position]);
             }
 
-            layers.push(FriProofLayer {
-                values: queried_values
-                    .into_iter()
-                    .map(|v| E::elements_as_bytes(&v).to_vec())
-                    .collect(),
-                paths: proof.nodes,
-                depth: proof.depth,
-            });
+            layers.push(FriProofLayer::new(queried_values, proof));
             domain_size /= FOLDING_FACTOR;
         }
 
@@ -175,11 +168,7 @@ where
         // clear layers so that another proof can be generated
         self.reset();
 
-        FriProof {
-            layers,
-            rem_values: E::elements_as_bytes(&remainder).to_vec(),
-            partitioned: false,
-        }
+        FriProof::new(layers, remainder, false)
     }
 
     /// Returns number of FRI layers computed during the last execution of build_layers() method
@@ -204,7 +193,7 @@ where
 ///   f'(x) = a + alpha * b + alpha^2 * c + alpha^3 * d, where alpha is a random coefficient
 /// - evaluate f'(x) on a domain which consists of x^4 from the original domain (and thus is
 ///   1/4 the size)
-/// note: that to compute an x in the new domain, we need 4 values from the old domain:
+/// note: to compute an x in the new domain, we need 4 values from the old domain:
 /// x^{1/4}, x^{2/4}, x^{3/4}, x
 fn apply_drp<B, E>(
     evaluations: &[[E; FOLDING_FACTOR]],

--- a/fri/src/prover/monolith/tests.rs
+++ b/fri/src/prover/monolith/tests.rs
@@ -36,6 +36,7 @@ fn sequential_fri_prove_verify() {
         commitments,
         &evaluations,
         max_degree,
+        lde_domain.len(),
         &positions,
         &options,
     );

--- a/fri/src/prover/tests.rs
+++ b/fri/src/prover/tests.rs
@@ -55,10 +55,16 @@ pub fn verify_proof(
     commitments: Vec<[u8; 32]>,
     evaluations: &[BaseElement],
     max_degree: usize,
+    domain_size: usize,
     positions: &[usize],
     options: &FriOptions<BaseElement>,
 ) -> Result<(), VerifierError> {
-    let channel = DefaultVerifierChannel::<BaseElement, hash::Blake3_256>::new(proof, commitments);
+    let channel = DefaultVerifierChannel::<BaseElement, hash::Blake3_256>::new(
+        proof,
+        commitments,
+        domain_size,
+    )
+    .unwrap();
     let context = VerifierContext::new(
         evaluations.len(),
         max_degree,

--- a/fri/src/verifier/mod.rs
+++ b/fri/src/verifier/mod.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use crate::{folding::quartic, utils};
+use crate::{folding::quartic, utils, VerifierError};
 use math::{
     field::{FieldElement, StarkField},
     polynom,
@@ -16,9 +16,6 @@ pub use context::VerifierContext;
 
 mod channel;
 pub use channel::{DefaultVerifierChannel, VerifierChannel};
-
-mod errors;
-pub use errors::VerifierError;
 
 // VERIFICATION PROCEDURE
 // ================================================================================================


### PR DESCRIPTION
This PR refactors FRI proof serialization/deserialization to be more in-line with main proof serialization. This is similar to #5, however, we cannot use `Queries` struct directly in FRI because the structures are slightly different.

The impact of this PR is further reduction of proof size by ~3% (in addition to the reduction from #15). It also lays groundwork in the FRI module for migration to the new Merkle tree implementation.