### PR TITLE
Field trait improvements

### DIFF
--- a/common/src/air/boundary/mod.rs
+++ b/common/src/air/boundary/mod.rs
@@ -19,21 +19,13 @@ mod tests;
 
 /// A group of boundary constraints all having the same divisor.
 #[derive(Debug, Clone)]
-pub struct BoundaryConstraintGroup<B, E>
-where
-    B: StarkField,
-    E: FieldElement + From<B>,
-{
+pub struct BoundaryConstraintGroup<B: StarkField, E: FieldElement<BaseField = B>> {
     constraints: Vec<BoundaryConstraint<B, E>>,
     divisor: ConstraintDivisor<B>,
     degree_adjustment: u32,
 }
 
-impl<B, E> BoundaryConstraintGroup<B, E>
-where
-    B: StarkField,
-    E: FieldElement + From<B>,
-{
+impl<B: StarkField, E: FieldElement<BaseField = B>> BoundaryConstraintGroup<B, E> {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
     pub fn new(
@@ -120,22 +112,14 @@ where
 
 /// Describes the numerator portion of a boundary constraint.
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct BoundaryConstraint<B, E>
-where
-    B: StarkField,
-    E: FieldElement + From<B>,
-{
+pub struct BoundaryConstraint<B: StarkField, E: FieldElement<BaseField = B>> {
     register: usize,
     poly: Vec<B>,
     poly_offset: (usize, B),
     cc: (E, E),
 }
 
-impl<B, E> BoundaryConstraint<B, E>
-where
-    B: StarkField,
-    E: FieldElement + From<B>,
-{
+impl<B: StarkField, E: FieldElement<BaseField = B>> BoundaryConstraint<B, E> {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Creates a new boundary constraint from the specified assertion.

--- a/common/src/air/divisor.rs
+++ b/common/src/air/divisor.rs
@@ -91,7 +91,7 @@ impl<B: StarkField> ConstraintDivisor<B> {
     // --------------------------------------------------------------------------------------------
 
     /// Evaluates the divisor at the provided `x` coordinate.
-    pub fn evaluate_at<E: FieldElement + From<B>>(&self, x: E) -> E {
+    pub fn evaluate_at<E: FieldElement<BaseField = B>>(&self, x: E) -> E {
         // compute the numerator value
         let mut numerator = E::ONE;
         for (degree, constant) in self.numerator.iter() {

--- a/common/src/air/mod.rs
+++ b/common/src/air/mod.rs
@@ -168,7 +168,7 @@ pub trait Air: Send + Sync {
     /// assign coefficients to each constraint, and group the constraints by denominator. The
     /// coefficients will be used to compute random linear combination of boundary constraints
     /// during constraint merging.
-    fn get_boundary_constraints<E: FieldElement + From<Self::BaseElement>>(
+    fn get_boundary_constraints<E: FieldElement<BaseField = Self::BaseElement>>(
         &self,
         coefficients: &[(E, E)],
     ) -> Vec<BoundaryConstraintGroup<Self::BaseElement, E>> {
@@ -307,10 +307,14 @@ pub trait Air: Send + Sync {
 
     /// Returns coefficients needed for random linear combination during construction of constraint
     /// composition polynomial.
-    fn get_constraint_composition_coeffs<E: FieldElement + From<Self::BaseElement>, H: Hasher>(
+    fn get_constraint_composition_coefficients<E, H>(
         &self,
         coin: &mut PublicCoin<Self::BaseElement, H>,
-    ) -> ConstraintCompositionCoefficients<E> {
+    ) -> ConstraintCompositionCoefficients<E>
+    where
+        E: FieldElement<BaseField = Self::BaseElement>,
+        H: Hasher,
+    {
         let num_t_constraints = self.num_transition_constraints();
         let num_b_constraints = self.get_assertions().len(); // TODO: this is heavy; do something lighter
 
@@ -322,10 +326,14 @@ pub trait Air: Send + Sync {
 
     /// Returns coefficients needed for random linear combinations during construction of DEEP
     /// composition polynomial.
-    fn get_deep_composition_coeffs<E: FieldElement + From<Self::BaseElement>, H: Hasher>(
+    fn get_deep_composition_coefficients<E, H>(
         &self,
         coin: &mut PublicCoin<Self::BaseElement, H>,
-    ) -> DeepCompositionCoefficients<E> {
+    ) -> DeepCompositionCoefficients<E>
+    where
+        E: FieldElement<BaseField = Self::BaseElement>,
+        H: Hasher,
+    {
         let trace_width = self.trace_width();
         let num_composition_columns = self.ce_blowup_factor();
 

--- a/crypto/src/random/mod.rs
+++ b/crypto/src/random/mod.rs
@@ -73,7 +73,7 @@ impl<B: StarkField, H: Hasher> PublicCoin<B, H> {
     /// Returns the next pseudo-random field element.
     ///
     /// Panics if a valid field element could not be generated after 100 calls to PRNG;
-    pub fn draw<E: FieldElement + From<B>>(&mut self) -> E {
+    pub fn draw<E: FieldElement<BaseField = B>>(&mut self) -> E {
         for _ in 0..100 {
             // get the next pseudo-random value and take the first ELEMENT_BYTES from it
             let value = self.next();
@@ -92,14 +92,14 @@ impl<B: StarkField, H: Hasher> PublicCoin<B, H> {
     /// Returns the next pair of pseudo-random field element.
     ///
     /// Panics if valid field elements could not be generated after 200 calls to PRNG;
-    pub fn draw_pair<E: FieldElement + From<B>>(&mut self) -> (E, E) {
+    pub fn draw_pair<E: FieldElement<BaseField = B>>(&mut self) -> (E, E) {
         (self.draw(), self.draw())
     }
 
     /// Returns the next triple of pseudo-random field elements.
     ///
     /// Panics if valid field elements could not be generated after 300 calls to PRNG;
-    pub fn draw_triple<E: FieldElement + From<B>>(&mut self) -> (E, E, E) {
+    pub fn draw_triple<E: FieldElement<BaseField = B>>(&mut self) -> (E, E, E) {
         (self.draw(), self.draw(), self.draw())
     }
 

--- a/fri/src/folding/quartic/concurrent.rs
+++ b/fri/src/folding/quartic/concurrent.rs
@@ -30,7 +30,7 @@ pub fn evaluate_batch<E: FieldElement>(polys: &[[E; FOLDING_FACTOR]], x: E) -> V
 pub fn interpolate_batch<B, E>(xs: &[[B; 4]], ys: &[[E; 4]]) -> Vec<[E; 4]>
 where
     B: StarkField,
-    E: FieldElement + From<B>,
+    E: FieldElement<BaseField = B>,
 {
     debug_assert!(
         xs.len() == ys.len(),

--- a/fri/src/folding/quartic/mod.rs
+++ b/fri/src/folding/quartic/mod.rs
@@ -53,7 +53,7 @@ pub fn evaluate_batch<E: FieldElement>(polys: &[[E; 4]], x: E) -> Vec<E> {
 pub fn interpolate_batch<B, E>(xs: &[[B; 4]], ys: &[[E; 4]]) -> Vec<[E; 4]>
 where
     B: StarkField,
-    E: FieldElement + From<B>,
+    E: FieldElement<BaseField = B>,
 {
     debug_assert!(
         xs.len() == ys.len(),
@@ -100,7 +100,7 @@ pub fn hash_values<H: Hasher, E: FieldElement>(values: &[[E; 4]]) -> Vec<H::Dige
 fn interpolate_batch_into<B, E>(xs: &[[B; 4]], ys: &[[E; 4]], result: &mut [[E; 4]])
 where
     B: StarkField,
-    E: FieldElement + From<B>,
+    E: FieldElement<BaseField = B>,
 {
     let n = xs.len();
     let mut equations: Vec<[E; 4]> = Vec::with_capacity(n * 4);

--- a/fri/src/prover/channel.rs
+++ b/fri/src/prover/channel.rs
@@ -24,7 +24,7 @@ pub trait ProverChannel<E: FieldElement> {
 // DEFAULT PROVER CHANNEL IMPLEMENTATION
 // ================================================================================================
 
-pub struct DefaultProverChannel<B: StarkField, E: FieldElement + From<B>, H: Hasher> {
+pub struct DefaultProverChannel<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher> {
     coin: PublicCoin<B, H>,
     commitments: Vec<H::Digest>,
     domain_size: usize,
@@ -32,7 +32,7 @@ pub struct DefaultProverChannel<B: StarkField, E: FieldElement + From<B>, H: Has
     _field_element: PhantomData<E>,
 }
 
-impl<B: StarkField, E: FieldElement + From<B>, H: Hasher> DefaultProverChannel<B, E, H> {
+impl<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher> DefaultProverChannel<B, E, H> {
     pub fn new(domain_size: usize, num_queries: usize) -> Self {
         DefaultProverChannel {
             coin: PublicCoin::new(&[]),
@@ -90,7 +90,7 @@ impl<B: StarkField, E: FieldElement + From<B>, H: Hasher> DefaultProverChannel<B
 impl<B, E, H> ProverChannel<E> for DefaultProverChannel<B, E, H>
 where
     B: StarkField,
-    E: FieldElement + From<B>,
+    E: FieldElement<BaseField = B>,
     H: Hasher,
 {
     type Hasher = H;

--- a/fri/src/verifier/context.rs
+++ b/fri/src/verifier/context.rs
@@ -10,7 +10,7 @@ use math::{
     utils::log2,
 };
 
-pub struct VerifierContext<B: StarkField, E: FieldElement + From<B>, H: Hasher> {
+pub struct VerifierContext<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher> {
     max_degree: usize,
     domain_size: usize,
     domain_generator: B,
@@ -20,7 +20,7 @@ pub struct VerifierContext<B: StarkField, E: FieldElement + From<B>, H: Hasher> 
     num_partitions: usize,
 }
 
-impl<B: StarkField, E: FieldElement + From<B>, H: Hasher> VerifierContext<B, E, H> {
+impl<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher> VerifierContext<B, E, H> {
     pub fn new(
         domain_size: usize,
         max_degree: usize,

--- a/fri/src/verifier/mod.rs
+++ b/fri/src/verifier/mod.rs
@@ -33,7 +33,7 @@ pub fn verify<B, E, H, C>(
 ) -> Result<(), VerifierError>
 where
     B: StarkField,
-    E: FieldElement + From<B>,
+    E: FieldElement<BaseField = B>,
     H: Hasher,
     C: VerifierChannel<E, Hasher = H>,
 {
@@ -140,16 +140,12 @@ where
 
 /// Returns Ok(true) if values in the `remainder` slice represent evaluations of a polynomial
 /// with degree < max_degree_plus_1 against a domain specified by the `domain_generator`.
-fn verify_remainder<B, E>(
+fn verify_remainder<B: StarkField, E: FieldElement<BaseField = B>>(
     remainder: Vec<E>,
     max_degree_plus_1: usize,
     domain_generator: B,
     blowup_factor: usize,
-) -> Result<(), VerifierError>
-where
-    B: StarkField,
-    E: FieldElement + From<B>,
-{
+) -> Result<(), VerifierError> {
     if max_degree_plus_1 > remainder.len() {
         return Err(VerifierError::RemainderDegreeNotValid);
     }

--- a/math/src/fft/concurrent.rs
+++ b/math/src/fft/concurrent.rs
@@ -15,11 +15,7 @@ use utils::uninit_vector;
 
 /// Evaluates polynomial `p` using FFT algorithm; the evaluation is done in-place, meaning
 /// `p` is updated with results of the evaluation.
-pub fn evaluate_poly<B, E>(p: &mut [E], twiddles: &[B])
-where
-    B: StarkField,
-    E: FieldElement + From<B>,
-{
+pub fn evaluate_poly<B: StarkField, E: FieldElement<BaseField = B>>(p: &mut [E], twiddles: &[B]) {
     split_radix_fft(p, twiddles);
     permute(p);
 }
@@ -27,16 +23,12 @@ where
 /// Evaluates polynomial `p` using FFT algorithm and returns the result. The polynomial is
 /// evaluated over domain specified by `twiddles`, expanded by the `blowup_factor`, and shifted
 /// by the `domain_offset`.
-pub fn evaluate_poly_with_offset<B, E>(
+pub fn evaluate_poly_with_offset<B: StarkField, E: FieldElement<BaseField = B>>(
     p: &[E],
     twiddles: &[B],
     domain_offset: B,
     blowup_factor: usize,
-) -> Vec<E>
-where
-    B: StarkField,
-    E: FieldElement + From<B>,
-{
+) -> Vec<E> {
     let domain_size = p.len() * blowup_factor;
     let g = B::get_root_of_unity(log2(domain_size));
     let mut result = uninit_vector(domain_size);
@@ -64,7 +56,7 @@ where
 pub fn interpolate_poly<B, E>(v: &mut [E], inv_twiddles: &[B])
 where
     B: StarkField,
-    E: FieldElement + From<B>,
+    E: FieldElement<BaseField = B>,
 {
     split_radix_fft(v, inv_twiddles);
     let inv_length = E::inv((v.len() as u64).into());
@@ -79,7 +71,7 @@ where
 pub fn interpolate_poly_with_offset<B, E>(values: &mut [E], inv_twiddles: &[B], domain_offset: B)
 where
     B: StarkField,
-    E: FieldElement + From<B>,
+    E: FieldElement<BaseField = B>,
 {
     split_radix_fft(values, inv_twiddles);
     permute(values);
@@ -131,7 +123,7 @@ pub fn permute<E: FieldElement>(v: &mut [E]) {
 
 /// In-place recursive FFT with permuted output.
 /// Adapted from: https://github.com/0xProject/OpenZKP/tree/master/algebra/primefield/src/fft
-pub(super) fn split_radix_fft<B: StarkField, E: FieldElement + From<B>>(
+pub(super) fn split_radix_fft<B: StarkField, E: FieldElement<BaseField = B>>(
     values: &mut [E],
     twiddles: &[B],
 ) {

--- a/math/src/fft/mod.rs
+++ b/math/src/fft/mod.rs
@@ -30,11 +30,7 @@ pub const MIN_CONCURRENT_SIZE: usize = 1024;
 /// When `concurrent` feature is enabled, the evaluation uses as many threads as are
 /// available in Rayon's global thread pool (usually as many threads as logical cores).
 /// Otherwise, the evaluation is done in a single thread.
-pub fn evaluate_poly<B, E>(p: &mut [E], twiddles: &[B])
-where
-    B: StarkField,
-    E: FieldElement + From<B>,
-{
+pub fn evaluate_poly<B: StarkField, E: FieldElement<BaseField = B>>(p: &mut [E], twiddles: &[B]) {
     assert!(
         p.len().is_power_of_two(),
         "number of coefficients must be a power of 2"
@@ -64,16 +60,12 @@ where
 /// When `concurrent` feature is enabled, the evaluation uses as many threads as are
 /// available in Rayon's global thread pool (usually as many threads as logical cores).
 /// Otherwise, the evaluation is done in a single thread.
-pub fn evaluate_poly_with_offset<B, E>(
+pub fn evaluate_poly_with_offset<B: StarkField, E: FieldElement<BaseField = B>>(
     p: &[E],
     twiddles: &[B],
     domain_offset: B,
     blowup_factor: usize,
-) -> Vec<E>
-where
-    B: StarkField,
-    E: FieldElement + From<B>,
-{
+) -> Vec<E> {
     assert!(
         p.len().is_power_of_two(),
         "number of coefficients must be a power of 2"
@@ -121,7 +113,7 @@ where
 pub fn interpolate_poly<B, E>(values: &mut [E], inv_twiddles: &[B])
 where
     B: StarkField,
-    E: FieldElement + From<B>,
+    E: FieldElement<BaseField = B>,
 {
     debug_assert!(
         values.len().is_power_of_two(),
@@ -155,7 +147,7 @@ where
 pub fn interpolate_poly_with_offset<B, E>(values: &mut [E], inv_twiddles: &[B], domain_offset: B)
 where
     B: StarkField,
-    E: FieldElement + From<B>,
+    E: FieldElement<BaseField = B>,
 {
     debug_assert!(
         values.len().is_power_of_two(),
@@ -225,7 +217,7 @@ pub fn get_inv_twiddles<B: StarkField>(domain_size: usize) -> Vec<B> {
 pub fn infer_degree<B, E>(evaluations: &[E], domain_offset: B) -> usize
 where
     B: StarkField,
-    E: FieldElement + From<B>,
+    E: FieldElement<BaseField = B>,
 {
     assert!(
         evaluations.len().is_power_of_two(),

--- a/math/src/fft/serial.rs
+++ b/math/src/fft/serial.rs
@@ -18,11 +18,7 @@ const MAX_LOOP: usize = 256;
 
 /// Evaluates polynomial `p` using FFT algorithm; the evaluation is done in-place, meaning
 /// `p` is updated with results of the evaluation.
-pub fn evaluate_poly<B, E>(p: &mut [E], twiddles: &[B])
-where
-    B: StarkField,
-    E: FieldElement + From<B>,
-{
+pub fn evaluate_poly<B: StarkField, E: FieldElement<BaseField = B>>(p: &mut [E], twiddles: &[B]) {
     fft_in_place(p, twiddles, 1, 1, 0);
     permute(p);
 }
@@ -30,16 +26,12 @@ where
 /// Evaluates polynomial `p` using FFT algorithm and returns the result. The polynomial is
 /// evaluated over domain specified by `twiddles`, expanded by the `blowup_factor`, and shifted
 /// by the `domain_offset`.
-pub fn evaluate_poly_with_offset<B, E>(
+pub fn evaluate_poly_with_offset<B: StarkField, E: FieldElement<BaseField = B>>(
     p: &[E],
     twiddles: &[B],
     domain_offset: B,
     blowup_factor: usize,
-) -> Vec<E>
-where
-    B: StarkField,
-    E: FieldElement + From<B>,
-{
+) -> Vec<E> {
     let domain_size = p.len() * blowup_factor;
     let g = B::get_root_of_unity(log2(domain_size));
     let mut result = uninit_vector(domain_size);
@@ -71,7 +63,7 @@ where
 pub fn interpolate_poly<B, E>(v: &mut [E], inv_twiddles: &[B])
 where
     B: StarkField,
-    E: FieldElement + From<B>,
+    E: FieldElement<BaseField = B>,
 {
     fft_in_place(v, inv_twiddles, 1, 1, 0);
     let inv_length = E::inv((v.len() as u64).into());
@@ -86,7 +78,7 @@ where
 pub fn interpolate_poly_with_offset<B, E>(values: &mut [E], inv_twiddles: &[B], domain_offset: B)
 where
     B: StarkField,
-    E: FieldElement + From<B>,
+    E: FieldElement<BaseField = B>,
 {
     fft_in_place(values, inv_twiddles, 1, 1, 0);
     permute(values);
@@ -117,16 +109,13 @@ pub fn permute<T>(values: &mut [T]) {
 
 /// In-place recursive FFT with permuted output.
 /// Adapted from: https://github.com/0xProject/OpenZKP/tree/master/algebra/primefield/src/fft
-pub(super) fn fft_in_place<B, E>(
+pub(super) fn fft_in_place<B: StarkField, E: FieldElement<BaseField = B>>(
     values: &mut [E],
     twiddles: &[B],
     count: usize,
     stride: usize,
     offset: usize,
-) where
-    B: StarkField,
-    E: FieldElement + From<B>,
-{
+) {
     let size = values.len() / stride;
     debug_assert!(size.is_power_of_two());
     debug_assert!(offset < stride);
@@ -174,7 +163,7 @@ fn butterfly<E: FieldElement>(values: &mut [E], offset: usize, stride: usize) {
 fn butterfly_twiddle<B, E>(values: &mut [E], twiddle: B, offset: usize, stride: usize)
 where
     B: StarkField,
-    E: FieldElement + From<B>,
+    E: FieldElement<BaseField = B>,
 {
     let i = offset;
     let j = offset + stride;

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -42,7 +42,7 @@ impl<B: StarkField> QuadExtension<B> {
 
 impl<B: StarkField> FieldElement for QuadExtension<B> {
     type PositiveInteger = B::PositiveInteger;
-    type Base = B;
+    type BaseField = B;
 
     const ELEMENT_BYTES: usize = B::ELEMENT_BYTES * 2;
     const ZERO: Self = Self(B::ZERO, B::ZERO);
@@ -98,7 +98,7 @@ impl<B: StarkField> FieldElement for QuadExtension<B> {
         let len = bytes.len() / Self::ELEMENT_BYTES;
 
         // make sure the bytes are aligned on the boundary consistent with base element alignment
-        if (p as usize) % Self::Base::ELEMENT_BYTES != 0 {
+        if (p as usize) % Self::BaseField::ELEMENT_BYTES != 0 {
             return Err(SerializationError::InvalidMemoryAlignment);
         }
 

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -51,7 +51,7 @@ impl BaseElement {
 
 impl FieldElement for BaseElement {
     type PositiveInteger = u128;
-    type Base = Self;
+    type BaseField = Self;
 
     const ZERO: Self = BaseElement(0);
     const ONE: Self = BaseElement(1);

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -63,7 +63,7 @@ impl BaseElement {
 
 impl FieldElement for BaseElement {
     type PositiveInteger = u64;
-    type Base = Self;
+    type BaseField = Self;
 
     const ZERO: Self = BaseElement::new(0);
     const ONE: Self = BaseElement::new(1);

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -37,6 +37,7 @@ pub trait FieldElement:
     + MulAssign<Self>
     + DivAssign<Self>
     + Neg<Output = Self>
+    + From<Self::BaseField>
     + From<u128>
     + From<u64>
     + From<u32>
@@ -57,7 +58,7 @@ pub trait FieldElement:
         + From<u32>
         + From<u64>;
 
-    type Base: StarkField;
+    type BaseField: StarkField;
 
     /// Number of bytes needed to encode an element
     const ELEMENT_BYTES: usize;
@@ -173,7 +174,7 @@ pub trait FieldElement:
 // STARK FIELD
 // ================================================================================================
 
-pub trait StarkField: FieldElement + AsBytes {
+pub trait StarkField: FieldElement<BaseField = Self> {
     /// Prime modulus of the field. Must be of the form k * 2^n + 1 (a Proth prime).
     /// This ensures that the field has high 2-adicity.
     const MODULUS: Self::PositiveInteger;

--- a/prover/src/channel.rs
+++ b/prover/src/channel.rs
@@ -18,7 +18,7 @@ use rayon::prelude::*;
 // TYPES AND INTERFACES
 // ================================================================================================
 
-pub struct ProverChannel<'a, A: Air, E: FieldElement + From<A::BaseElement>, H: Hasher> {
+pub struct ProverChannel<'a, A: Air, E: FieldElement<BaseField = A::BaseElement>, H: Hasher> {
     air: &'a A,
     coin: PublicCoin<A::BaseElement, H>,
     context: Context,
@@ -31,7 +31,9 @@ pub struct ProverChannel<'a, A: Air, E: FieldElement + From<A::BaseElement>, H: 
 // PROVER CHANNEL IMPLEMENTATION
 // ================================================================================================
 
-impl<'a, A: Air, E: FieldElement + From<A::BaseElement>, H: Hasher> ProverChannel<'a, A, E, H> {
+impl<'a, A: Air, E: FieldElement<BaseField = A::BaseElement>, H: Hasher>
+    ProverChannel<'a, A, E, H>
+{
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Creates a new prover channel for the specified `air` and public inputs.
@@ -91,7 +93,8 @@ impl<'a, A: Air, E: FieldElement + From<A::BaseElement>, H: Hasher> ProverChanne
     /// Returns a set of coefficients for constructing a constraint composition polynomial drawn
     /// from the public coin.
     pub fn get_constraint_composition_coeffs(&mut self) -> ConstraintCompositionCoefficients<E> {
-        self.air.get_constraint_composition_coeffs(&mut self.coin)
+        self.air
+            .get_constraint_composition_coefficients(&mut self.coin)
     }
 
     /// Returns an out-of-domain point drawn from the public coin.
@@ -102,7 +105,7 @@ impl<'a, A: Air, E: FieldElement + From<A::BaseElement>, H: Hasher> ProverChanne
     /// Returns a set of coefficients for constructing a DEEP composition polynomial drawn from
     /// the public coin.
     pub fn get_deep_composition_coeffs(&mut self) -> DeepCompositionCoefficients<E> {
-        self.air.get_deep_composition_coeffs(&mut self.coin)
+        self.air.get_deep_composition_coefficients(&mut self.coin)
     }
 
     /// Returns a set of positions in the LDE domain against which the evaluations of trace and
@@ -162,7 +165,7 @@ impl<'a, A: Air, E: FieldElement + From<A::BaseElement>, H: Hasher> ProverChanne
 impl<'a, A, E, H> fri::ProverChannel<E> for ProverChannel<'a, A, E, H>
 where
     A: Air,
-    E: FieldElement + From<A::BaseElement>,
+    E: FieldElement<BaseField = A::BaseElement>,
     H: Hasher,
 {
     type Hasher = H;

--- a/prover/src/monolith/constraints/boundary.rs
+++ b/prover/src/monolith/constraints/boundary.rs
@@ -23,14 +23,14 @@ const SMALL_POLY_DEGREE: usize = 63;
 
 /// Contains constraints all having the same divisor. The constraints are separated into single
 /// value constraints, small polynomial constraints, and large polynomial constraints.
-pub struct BoundaryConstraintGroup<B: StarkField, E: FieldElement + From<B>> {
+pub struct BoundaryConstraintGroup<B: StarkField, E: FieldElement<BaseField = B>> {
     pub(super) degree_adjustment: u32,
     single_value_constraints: Vec<SingleValueConstraint<B, E>>,
     small_poly_constraints: Vec<SmallPolyConstraint<B, E>>,
     large_poly_constraints: Vec<LargePolyConstraint<B, E>>,
 }
 
-impl<B: StarkField, E: FieldElement + From<B>> BoundaryConstraintGroup<B, E> {
+impl<B: StarkField, E: FieldElement<BaseField = B>> BoundaryConstraintGroup<B, E> {
     /// Creates a new specialized constraint group; twiddles and ce_blowup_factor are passed in for
     /// evaluating large polynomial constraints (if any).
     pub fn new(
@@ -115,13 +115,13 @@ impl<B: StarkField, E: FieldElement + From<B>> BoundaryConstraintGroup<B, E> {
 
 /// A constraint where the numerator can be represented by p(x) - v, where v is the asserted value,
 /// and p(x) is the trace polynomial for the register against which the constraint is applied.
-struct SingleValueConstraint<B: StarkField, E: FieldElement + From<B>> {
+struct SingleValueConstraint<B: StarkField, E: FieldElement<BaseField = B>> {
     register: usize,
     value: B,
     coefficients: (E, E),
 }
 
-impl<B: StarkField, E: FieldElement + From<B>> SingleValueConstraint<B, E> {
+impl<B: StarkField, E: FieldElement<BaseField = B>> SingleValueConstraint<B, E> {
     pub fn evaluate(&self, state: &[B], xp: E) -> E {
         let evaluation = E::from(state[self.register] - self.value);
         evaluation * (self.coefficients.0 + self.coefficients.1 * xp)
@@ -131,14 +131,14 @@ impl<B: StarkField, E: FieldElement + From<B>> SingleValueConstraint<B, E> {
 /// A constraint where the numerator can be represented by p(x) - c(x), where c(x) is the
 /// polynomial describing a set of asserted values. This specialization is useful when the
 // degree of c(x) is relatively small, and thus, is cheap to evaluate on the fly.
-struct SmallPolyConstraint<B: StarkField, E: FieldElement + From<B>> {
+struct SmallPolyConstraint<B: StarkField, E: FieldElement<BaseField = B>> {
     register: usize,
     poly: Vec<B>,
     x_offset: B,
     coefficients: (E, E),
 }
 
-impl<B: StarkField, E: FieldElement + From<B>> SmallPolyConstraint<B, E> {
+impl<B: StarkField, E: FieldElement<BaseField = B>> SmallPolyConstraint<B, E> {
     pub fn evaluate(&self, state: &[B], x: B, xp: E) -> E {
         let x = x * self.x_offset;
         // evaluate constraint polynomial as x * offset
@@ -151,14 +151,14 @@ impl<B: StarkField, E: FieldElement + From<B>> SmallPolyConstraint<B, E> {
 /// A constraint where the numerator can be represented by p(x) - c(x), where c(x) is a large
 /// polynomial. In such cases, we pre-compute evaluations of c(x) by evaluating it over the
 /// entire constraint evaluation domain (using FFT).
-struct LargePolyConstraint<B: StarkField, E: FieldElement + From<B>> {
+struct LargePolyConstraint<B: StarkField, E: FieldElement<BaseField = B>> {
     register: usize,
     values: Vec<B>,
     step_offset: usize,
     coefficients: (E, E),
 }
 
-impl<B: StarkField, E: FieldElement + From<B>> LargePolyConstraint<B, E> {
+impl<B: StarkField, E: FieldElement<BaseField = B>> LargePolyConstraint<B, E> {
     pub fn evaluate(&self, state: &[B], ce_step: usize, xp: E) -> E {
         let value_index = if self.step_offset > 0 {
             // if the assertion happens on steps which are not a power of 2, we need to offset the

--- a/prover/src/monolith/constraints/evaluation_table.rs
+++ b/prover/src/monolith/constraints/evaluation_table.rs
@@ -24,7 +24,7 @@ const MIN_FRAGMENT_SIZE: usize = 256;
 // CONSTRAINT EVALUATION TABLE
 // ================================================================================================
 
-pub struct ConstraintEvaluationTable<B: StarkField, E: FieldElement + From<B>> {
+pub struct ConstraintEvaluationTable<B: StarkField, E: FieldElement<BaseField = B>> {
     evaluations: Vec<Vec<E>>,
     divisors: Vec<ConstraintDivisor<B>>,
     domain_offset: B,
@@ -36,7 +36,7 @@ pub struct ConstraintEvaluationTable<B: StarkField, E: FieldElement + From<B>> {
     t_expected_degrees: Vec<usize>,
 }
 
-impl<B: StarkField, E: FieldElement + From<B>> ConstraintEvaluationTable<B, E> {
+impl<B: StarkField, E: FieldElement<BaseField = B>> ConstraintEvaluationTable<B, E> {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Returns a new constraint evaluation table with number of columns equal to the number of
@@ -137,7 +137,7 @@ impl<B: StarkField, E: FieldElement + From<B>> ConstraintEvaluationTable<B, E> {
     /// Divides constraint evaluation columns by their respective divisor (in evaluation form),
     /// combines the results into a single column, and interpolates this column into a composition
     /// polynomial in coefficient form.
-    pub fn into_poly(self) -> Result<CompositionPoly<E>, ProverError> {
+    pub fn into_poly(self) -> Result<CompositionPoly<B, E>, ProverError> {
         let domain_offset = self.domain_offset;
 
         // allocate memory for the combined polynomial
@@ -251,7 +251,7 @@ impl<'a, E: FieldElement> TableFragment<'a, E> {
 // ================================================================================================
 
 #[allow(clippy::many_single_char_names)]
-fn acc_column<B: StarkField, E: FieldElement + From<B>>(
+fn acc_column<B: StarkField, E: FieldElement<BaseField = B>>(
     column: Vec<E>,
     divisor: &ConstraintDivisor<B>,
     domain_offset: B,
@@ -390,7 +390,7 @@ fn get_inv_evaluation<B: StarkField>(
 
 /// Makes sure that the post-division degree of the polynomial matches the expected degree
 #[cfg(debug_assertions)]
-fn validate_column_degree<B: StarkField, E: FieldElement + From<B>>(
+fn validate_column_degree<B: StarkField, E: FieldElement<BaseField = B>>(
     column: &[E],
     divisor: &ConstraintDivisor<B>,
     domain_offset: B,

--- a/prover/src/monolith/constraints/evaluator.rs
+++ b/prover/src/monolith/constraints/evaluator.rs
@@ -24,7 +24,7 @@ const MIN_CONCURRENT_DOMAIN_SIZE: usize = 8192;
 // CONSTRAINT EVALUATOR
 // ================================================================================================
 
-pub struct ConstraintEvaluator<'a, A: Air, E: FieldElement + From<A::BaseElement>> {
+pub struct ConstraintEvaluator<'a, A: Air, E: FieldElement<BaseField = A::BaseElement>> {
     air: &'a A,
     boundary_constraints: Vec<BoundaryConstraintGroup<A::BaseElement, E>>,
     transition_constraints: Vec<TransitionConstraintGroup<E>>,
@@ -35,7 +35,7 @@ pub struct ConstraintEvaluator<'a, A: Air, E: FieldElement + From<A::BaseElement
     transition_constraint_degrees: Vec<usize>,
 }
 
-impl<'a, A: Air, E: FieldElement + From<A::BaseElement>> ConstraintEvaluator<'a, A, E> {
+impl<'a, A: Air, E: FieldElement<BaseField = A::BaseElement>> ConstraintEvaluator<'a, A, E> {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Returns a new evaluator which can be used to evaluate transition and boundary constraints

--- a/prover/src/monolith/mod.rs
+++ b/prover/src/monolith/mod.rs
@@ -85,7 +85,7 @@ pub fn prove<AIR: Air>(
 // ================================================================================================
 /// Performs the actual proof generation procedure, generating the proof that the provided
 /// execution `trace` is valid against the provided `air`.
-fn generate_proof<A: Air, E: FieldElement + From<A::BaseElement>, H: Hasher>(
+fn generate_proof<A: Air, E: FieldElement<BaseField = A::BaseElement>, H: Hasher>(
     air: A,
     trace: ExecutionTrace<A::BaseElement>,
     pub_inputs_bytes: Vec<u8>,

--- a/prover/src/monolith/trace/poly_table.rs
+++ b/prover/src/monolith/trace/poly_table.rs
@@ -46,7 +46,7 @@ impl<B: StarkField> TracePolyTable<B> {
     }
 
     /// Evaluates all trace polynomials the the specified point `x`.
-    pub fn evaluate_at<E: FieldElement + From<B>>(&self, x: E) -> Vec<E> {
+    pub fn evaluate_at<E: FieldElement<BaseField = B>>(&self, x: E) -> Vec<E> {
         #[cfg(not(feature = "concurrent"))]
         let result = self.0.iter().map(|p| polynom::eval(p, x)).collect();
 
@@ -58,7 +58,7 @@ impl<B: StarkField> TracePolyTable<B> {
 
     /// Returns an out-of-domain evaluation frame constructed by evaluating trace polynomials
     /// for all registers at points z and z * g, where g is the generator of the trace domain.
-    pub fn get_ood_frame<E: FieldElement + From<B>>(&self, z: E) -> EvaluationFrame<E> {
+    pub fn get_ood_frame<E: FieldElement<BaseField = B>>(&self, z: E) -> EvaluationFrame<E> {
         let g = E::from(B::get_root_of_unity(log2(self.poly_size())));
         EvaluationFrame {
             current: self.evaluate_at(z),

--- a/verifier/src/channel.rs
+++ b/verifier/src/channel.rs
@@ -11,7 +11,7 @@ use math::field::{FieldElement, StarkField};
 // TYPES AND INTERFACES
 // ================================================================================================
 
-pub struct VerifierChannel<B: StarkField, E: FieldElement + From<B>, H: Hasher> {
+pub struct VerifierChannel<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher> {
     // trace queries
     trace_root: H::Digest,
     trace_proof: BatchMerkleProof<H>,
@@ -36,7 +36,7 @@ pub struct VerifierChannel<B: StarkField, E: FieldElement + From<B>, H: Hasher> 
 // VERIFIER CHANNEL IMPLEMENTATION
 // ================================================================================================
 
-impl<B: StarkField, E: FieldElement + From<B>, H: Hasher> VerifierChannel<B, E, H> {
+impl<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher> VerifierChannel<B, E, H> {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Creates and returns a new verifier channel initialized from the specified `proof`.
@@ -195,7 +195,7 @@ impl<B: StarkField, E: FieldElement + From<B>, H: Hasher> VerifierChannel<B, E, 
 impl<B, E, H> FriVerifierChannel<E> for VerifierChannel<B, E, H>
 where
     B: StarkField,
-    E: FieldElement + From<B>,
+    E: FieldElement<BaseField = B>,
     H: Hasher,
 {
     type Hasher = H;

--- a/verifier/src/evaluator.rs
+++ b/verifier/src/evaluator.rs
@@ -10,7 +10,7 @@ use math::{field::FieldElement, polynom};
 // ================================================================================================
 
 /// Evaluates constraints for the specified evaluation frame.
-pub fn evaluate_constraints<A: Air, E: FieldElement + From<A::BaseElement>>(
+pub fn evaluate_constraints<A: Air, E: FieldElement<BaseField = A::BaseElement>>(
     air: &A,
     coefficients: ConstraintCompositionCoefficients<E>,
     ood_frame: &EvaluationFrame<E>,

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -83,7 +83,7 @@ pub fn verify<AIR: Air>(
 // ================================================================================================
 /// Performs the actual verification by reading the data from the `channel` and making sure it
 /// attests to a correct execution of the computation specified by the provided `air`.
-fn perform_verification<A: Air, E: FieldElement + From<A::BaseElement>, H: Hasher>(
+fn perform_verification<A: Air, E: FieldElement<BaseField = A::BaseElement>, H: Hasher>(
     air: A,
     mut channel: VerifierChannel<A::BaseElement, E, H>,
     mut coin: PublicCoin<A::BaseElement, H>,
@@ -95,7 +95,7 @@ fn perform_verification<A: Air, E: FieldElement + From<A::BaseElement>, H: Hashe
     // the prover, and prover uses them to compute constraint composition polynomial.
     let trace_commitment = channel.read_trace_commitment();
     coin.reseed(trace_commitment);
-    let constraint_coeffs = air.get_constraint_composition_coeffs(&mut coin);
+    let constraint_coeffs = air.get_constraint_composition_coefficients(&mut coin);
 
     // 2 ----- constraint commitment --------------------------------------------------------------
     // read the commitment to evaluations of the constraint composition polynomial over the LDE
@@ -141,7 +141,7 @@ fn perform_verification<A: Air, E: FieldElement + From<A::BaseElement>, H: Hashe
     // interactive version of the protocol, the verifier sends these coefficients to the prover
     // and the prover uses them to compute the DEEP composition polynomial. the prover, then
     // applies FRI protocol to the evaluations of the DEEP composition polynomial.
-    let deep_coefficients = air.get_deep_composition_coeffs::<E, H>(&mut coin);
+    let deep_coefficients = air.get_deep_composition_coefficients::<E, H>(&mut coin);
 
     // read FRI layer commitments sent by the prover, and use each commitment to update the public
     // coin and draw a random point alpha from it; in the interactive version of the protocol, the


### PR DESCRIPTION
This PR implements tighter bounds for field types. Specifically, instead of passing field elements as: `<B: StarkField, E: FieldElement + From<B>>`, we now say `<B: StarkField, E: FieldElement<BaseField = B>>`.