### PR TITLE
Extension field specifier

### DIFF
--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -3,7 +3,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::traits::{FieldElement, StarkField};
+use super::{
+    traits::{FieldElement, StarkField},
+    QuadExtension,
+};
 use crate::errors::SerializationError;
 use core::{
     convert::{TryFrom, TryInto},
@@ -132,6 +135,8 @@ impl FieldElement for BaseElement {
 }
 
 impl StarkField for BaseElement {
+    type QuadExtension = QuadExtension<Self>;
+
     /// sage: MODULUS = 2^128 - 45 * 2^40 + 1
     /// sage: GF(MODULUS).is_prime_field()
     /// True

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -3,7 +3,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::traits::{FieldElement, StarkField};
+use super::{
+    traits::{FieldElement, StarkField},
+    QuadExtension,
+};
 use crate::errors::{ElementDecodingError, SerializationError};
 use core::{
     convert::{TryFrom, TryInto},
@@ -163,6 +166,8 @@ impl FieldElement for BaseElement {
 }
 
 impl StarkField for BaseElement {
+    type QuadExtension = QuadExtension<Self>;
+
     /// sage: MODULUS = 2^62 - 111 * 2^39 + 1
     /// sage: GF(MODULUS).is_prime_field()
     /// True

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -175,6 +175,9 @@ pub trait FieldElement:
 // ================================================================================================
 
 pub trait StarkField: FieldElement<BaseField = Self> {
+    /// Type describing quadratic extension of this StarkField.
+    type QuadExtension: FieldElement<BaseField = Self>;
+
     /// Prime modulus of the field. Must be of the form k * 2^n + 1 (a Proth prime).
     /// This ensures that the field has high 2-adicity.
     const MODULUS: Self::PositiveInteger;

--- a/prover/src/monolith/mod.rs
+++ b/prover/src/monolith/mod.rs
@@ -12,7 +12,7 @@ use crypto::hash::{Blake3_256, Hasher, Sha3_256};
 use log::debug;
 use math::{
     fft::infer_degree,
-    field::{FieldElement, QuadExtension},
+    field::{FieldElement, StarkField},
     utils::log2,
 };
 use std::time::Instant;
@@ -68,15 +68,15 @@ pub fn prove<AIR: Air>(
             }
             HashFunction::Sha3_256 => {
                 generate_proof::<AIR, AIR::BaseElement, Sha3_256>(air, trace, pub_inputs_bytes)
-            },
+            }
         },
         FieldExtension::Quadratic => match air.context().options().hash_fn() {
-            HashFunction::Blake3_256 => {
-                generate_proof::<AIR, QuadExtension<AIR::BaseElement>, Blake3_256>(air, trace, pub_inputs_bytes)
-            }
-            HashFunction::Sha3_256 => {
-                generate_proof::<AIR, QuadExtension<AIR::BaseElement>, Sha3_256>(air, trace, pub_inputs_bytes)
-            }
+            HashFunction::Blake3_256 => generate_proof::
+                <AIR, <AIR::BaseElement as StarkField>::QuadExtension, Blake3_256>
+                (air, trace, pub_inputs_bytes),
+            HashFunction::Sha3_256 => generate_proof::
+                <AIR, <AIR::BaseElement as StarkField>::QuadExtension, Sha3_256>
+                (air, trace, pub_inputs_bytes),
         },
     }
 }

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -15,7 +15,7 @@ use crypto::{
 };
 
 pub use math;
-use math::field::{FieldElement, QuadExtension};
+use math::field::{FieldElement, StarkField};
 
 mod channel;
 use channel::VerifierChannel;
@@ -68,12 +68,16 @@ pub fn verify<AIR: Air>(
             HashFunction::Blake3_256 => {
                 let coin = PublicCoin::new(&coin_seed);
                 let channel = VerifierChannel::new(&air, proof)?;
-                perform_verification::<AIR, QuadExtension<AIR::BaseElement>, Blake3_256>(air, channel, coin)
+                perform_verification::
+                    <AIR, <AIR::BaseElement as StarkField>::QuadExtension, Blake3_256>
+                    (air, channel, coin)
             }
             HashFunction::Sha3_256 => {
                 let coin = PublicCoin::new(&coin_seed);
                 let channel = VerifierChannel::new(&air, proof)?;
-                perform_verification::<AIR, QuadExtension<AIR::BaseElement>, Sha3_256>(air, channel, coin)
+                perform_verification::
+                    <AIR, <AIR::BaseElement as StarkField>::QuadExtension, Sha3_256>
+                    (air, channel, coin)
             }
         },
     }


### PR DESCRIPTION
This PR implements a new way to specify extension fields for a given base field. Basically, `StarkField` trait now exposes a type called `QuadExtension` which can be used to describe quadratic extension of a specific `StarkField`. This approach is more flexibly and should make addressing #12 easier.