### PR TITLE
Custom proof serialization

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,7 +18,6 @@ utils = { path = "../utils", package = "winter-utils" }
 math = { path = "../math", package = "winter-math" }
 crypto = { path = "../crypto", package = "winter-crypto" }
 fri = { path = "../fri", package = "winter-fri" }
-serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/common/src/options.rs
+++ b/common/src/options.rs
@@ -59,6 +59,7 @@ impl ProofOptions {
         fri_folding_factor: usize,
         fri_max_remainder_size: usize,
     ) -> ProofOptions {
+        // TODO: return errors instead of panicking
         assert!(num_queries > 0, "number of queries must be greater than 0");
         assert!(num_queries <= 128, "number of queries cannot be greater than 128");
 

--- a/common/src/proof/commitments.rs
+++ b/common/src/proof/commitments.rs
@@ -5,16 +5,18 @@
 
 use crate::errors::ProofSerializationError;
 use crypto::Hasher;
-use serde::{Deserialize, Serialize};
+use utils::{read_u16, read_u8_vec, DeserializationError};
 
 // COMMITMENTS
 // ================================================================================================
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Commitments(Vec<u8>);
 
 impl Commitments {
-    /// Serializes the provided commitments into a vector of bytes.
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns a new Commitments struct initialized with the provided commitments.
     pub fn new<H: Hasher>(
         trace_root: H::Digest,
         constraint_root: H::Digest,
@@ -29,10 +31,16 @@ impl Commitments {
         Commitments(bytes)
     }
 
+    // PUBLIC METHODS
+    // --------------------------------------------------------------------------------------------
+
     /// Adds the specified commitment to the list of commitments.
     pub fn add<H: Hasher>(&mut self, commitment: &H::Digest) {
         self.0.extend_from_slice(commitment.as_ref())
     }
+
+    // PARSING
+    // --------------------------------------------------------------------------------------------
 
     /// Parses the serialized commitments into distinct parts.
     #[allow(clippy::type_complexity)]
@@ -52,6 +60,25 @@ impl Commitments {
             ));
         }
         Ok((commitments[0], commitments[1], commitments[2..].to_vec()))
+    }
+
+    // SERIALIZATION / DESERIALIZATION
+    // --------------------------------------------------------------------------------------------
+
+    /// Serializes these commitments and appends the resulting bytes to the `target` vector.
+    pub fn write_into(&self, target: &mut Vec<u8>) {
+        assert!(self.0.len() < u16::MAX as usize);
+        target.extend_from_slice(&(self.0.len() as u16).to_le_bytes());
+        target.extend_from_slice(&self.0);
+    }
+
+    /// Reads commitments from the specified source starting at the specified position and
+    /// increments `pos` to point to a position right after the end of read-in commitment bytes.
+    /// Returns an error of a valid Commitments struct could not be read from the specified source.
+    pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
+        let num_bytes = read_u16(source, pos)? as usize;
+        let result = read_u8_vec(source, pos, num_bytes)?;
+        Ok(Commitments(result))
     }
 }
 

--- a/common/src/proof/queries.rs
+++ b/common/src/proof/queries.rs
@@ -21,6 +21,8 @@ pub struct Queries {
 }
 
 impl Queries {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
     /// Returns a set of queries constructed from a batch Merkle proof and corresponding elements.
     pub fn new<H: Hasher, E: FieldElement>(
         merkle_proof: BatchMerkleProof<H>,
@@ -54,6 +56,8 @@ impl Queries {
         Queries { paths, values }
     }
 
+    // PARSER
+    // --------------------------------------------------------------------------------------------
     /// Convert a set of queries into a batch Merkle proof and corresponding query values.
     pub fn parse<H: Hasher, E: FieldElement>(
         self,

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -30,7 +30,6 @@ utils = { path = "../utils", package = "winter-utils" }
 math = { path = "../math", package = "winter-math" }
 blake3 = "0.3"
 sha3 = "0.9"
-serde = { version = "1.0", features = ["derive"] }
 rayon = { version = "1.5", optional = true }
 
 [dev-dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -27,9 +27,7 @@ hex = "0.4"
 log = "0.4"
 blake3 = "0.3"
 env_logger = "0.8"
-bincode = "1.3"
 structopt = "0.3"
-serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/examples/src/lamport/signature.rs
+++ b/examples/src/lamport/signature.rs
@@ -8,7 +8,6 @@ use prover::{
     math::field::{f128::BaseElement, FieldElement, StarkField},
     Serializable,
 };
-use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, convert::TryInto};
 
 // CONSTANTS
@@ -27,10 +26,9 @@ pub struct PrivateKey {
     pub_key_hash: PublicKey,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PublicKey(KeyData);
 
-#[derive(Serialize, Deserialize)]
 pub struct Signature {
     pub ones: Vec<KeyData>,
     pub zeros: Vec<KeyData>,

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -4,6 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use log::debug;
+use prover::StarkProof;
 use std::io::Write;
 use std::time::Instant;
 use structopt::StructOpt;
@@ -55,7 +56,8 @@ fn main() {
         "---------------------\nProof generated in {} ms",
         now.elapsed().as_millis()
     );
-    let proof_bytes = bincode::serialize(&proof).unwrap();
+
+    let proof_bytes = proof.to_bytes();
     debug!("Proof size: {:.1} KB", proof_bytes.len() as f64 / 1024f64);
     debug!("Proof security: {} bits", proof.security_level(true));
     debug!(
@@ -65,7 +67,8 @@ fn main() {
 
     // verify the proof
     debug!("---------------------");
-    let proof = bincode::deserialize(&proof_bytes).expect("proof deserialization failed");
+    let parsed_proof = StarkProof::from_bytes(&proof_bytes).unwrap();
+    assert_eq!(proof, parsed_proof);
     let now = Instant::now();
     match example.verify(proof) {
         Ok(_) => debug!(

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -29,7 +29,6 @@ utils = { path = "../utils", package = "winter-utils" }
 math = { path = "../math", package = "winter-math" }
 crypto = { path = "../crypto", package = "winter-crypto" }
 rayon = { version = "1.5", optional = true }
-serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/fri/src/errors.rs
+++ b/fri/src/errors.rs
@@ -60,26 +60,26 @@ impl fmt::Display for VerifierError {
 
 #[derive(Debug, PartialEq)]
 pub enum ProofSerializationError {
-    /// FRI queries at layer {} could not be deserialized: {0}
-    LayerDeserializationError(usize, String),
+    /// FRI queries at layer {0} could not be parsed: {1}
+    LayerParsingError(usize, String),
     /// FRI remainder domain size must be {0}, but was {1}
     InvalidRemainderDomain(usize, usize),
-    /// FRI remainder could not be deserialized: {0}
-    RemainderDeserializationError(String),
+    /// FRI remainder could not be parsed: {0}
+    RemainderParsingError(String),
 }
 
 impl fmt::Display for ProofSerializationError {
     #[rustfmt::skip]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::LayerDeserializationError(layer, err_msg) => {
-                write!(f, "FRI queries at layer {} could not be deserialized: {}", layer, err_msg)
+            Self::LayerParsingError(layer, err_msg) => {
+                write!(f, "FRI queries at layer {} could not be parsed: {}", layer, err_msg)
             }
             Self::InvalidRemainderDomain(num_remainder_elements, domain_size) => {
                 write!(f, "FRI remainder domain size must be {}, but was {}", num_remainder_elements, domain_size)
             }
-            Self::RemainderDeserializationError(err_msg) => {
-                write!(f, "FRI remainder could not be deserialized: {}", err_msg)
+            Self::RemainderParsingError(err_msg) => {
+                write!(f, "FRI remainder could not be parsed: {}", err_msg)
             }
         }
     }

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -11,12 +11,10 @@ use math::{
 };
 use utils::{read_u32, read_u8, read_u8_vec, DeserializationError};
 
-use serde::{Deserialize, Serialize};
-
 // FRI PROOF
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FriProof {
     layers: Vec<FriProofLayer>,
     remainder: Vec<u8>,
@@ -107,8 +105,7 @@ impl FriProof {
     // SERIALIZATION
     // --------------------------------------------------------------------------------------------
 
-    /// Serializes this FRI proof and writes it into the specified target vector. Proof bytes are
-    /// appended at the end of the vector.
+    /// Serializes proof and appends the resulting bytes to the `target` vector.
     pub fn write_into(&self, target: &mut Vec<u8>) {
         // write layers
         target.push(self.layers.len() as u8);
@@ -153,7 +150,7 @@ impl FriProof {
 // FRI PROOF LAYER
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FriProofLayer {
     values: Vec<u8>,
     paths: Vec<u8>,
@@ -236,8 +233,7 @@ impl FriProofLayer {
         Ok((query_values, merkle_proof))
     }
 
-    /// Writes this layer into the provided vector of bytes. Layer bytes are appended at the
-    /// end of the vector.
+    /// Serializes proof layer context and appends the resulting bytes to the `target` vector.
     pub fn write_into(&self, target: &mut Vec<u8>) {
         // write value bytes
         target.extend_from_slice(&(self.values.len() as u32).to_le_bytes());
@@ -248,8 +244,9 @@ impl FriProofLayer {
         target.extend_from_slice(&self.paths);
     }
 
-    /// Reads a single proof layer form the specified source starting at the specified position.
-    /// Returns an error if a valid layer could not be read from the source.
+    /// Reads a single proof layer form the specified source starting at the specified position,
+    /// and increments `pos` to point to a position right after the end of read-in layer bytes.
+    /// Returns an error if a valid layer could not be read from the specified source.
     pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
         // read values
         let num_value_bytes = read_u32(source, pos)?;

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -70,9 +70,6 @@ impl FriProof {
             "folding factor must be a power of two"
         );
 
-        // cache the number of remainder elements here for comparison later
-        let num_remainder_elements = self.remainder.len() / E::ELEMENT_BYTES;
-
         let mut layer_proofs = Vec::new();
         let mut layer_queries = Vec::new();
 
@@ -85,6 +82,7 @@ impl FriProof {
         }
 
         // make sure the remaining domain size matches remainder length
+        let num_remainder_elements = self.remainder.len() / E::ELEMENT_BYTES;
         if domain_size != num_remainder_elements {
             return Err(ProofSerializationError::InvalidRemainderDomain(
                 num_remainder_elements,
@@ -102,10 +100,10 @@ impl FriProof {
         Ok(remainder)
     }
 
-    // SERIALIZATION
+    // SERIALIZATION / DESERIALIZATION
     // --------------------------------------------------------------------------------------------
 
-    /// Serializes proof and appends the resulting bytes to the `target` vector.
+    /// Serializes this proof and appends the resulting bytes to the `target` vector.
     pub fn write_into(&self, target: &mut Vec<u8>) {
         // write layers
         target.push(self.layers.len() as u8);
@@ -157,6 +155,8 @@ pub struct FriProofLayer {
 }
 
 impl FriProofLayer {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
     /// Creates a new proof layer from the specified query values and the corresponding Merkle
     /// paths aggregated into a single batch Merkle proof.
     pub fn new<H: Hasher, E: FieldElement, const N: usize>(
@@ -180,6 +180,9 @@ impl FriProofLayer {
 
         FriProofLayer { values, paths }
     }
+
+    // PARSING
+    // --------------------------------------------------------------------------------------------
 
     /// Decomposes this layer into a combination of query values and corresponding Merkle
     /// paths (grouped together into a single batch Merkle proof).
@@ -233,7 +236,10 @@ impl FriProofLayer {
         Ok((query_values, merkle_proof))
     }
 
-    /// Serializes proof layer context and appends the resulting bytes to the `target` vector.
+    // SERIALIZATION / DESERIALIZATION
+    // --------------------------------------------------------------------------------------------
+
+    /// Serializes this proof layer and appends the resulting bytes to the `target` vector.
     pub fn write_into(&self, target: &mut Vec<u8>) {
         // write value bytes
         target.extend_from_slice(&(self.values.len() as u32).to_le_bytes());

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -9,6 +9,7 @@ use math::{
     field::FieldElement,
     utils::{log2, read_elements_into_vec},
 };
+use utils::{read_u32, read_u8, read_u8_vec, DeserializationError};
 
 use serde::{Deserialize, Serialize};
 
@@ -23,6 +24,8 @@ pub struct FriProof {
 }
 
 impl FriProof {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
     /// Creates a new FRI proof from the provided layers and remainder values.
     pub fn new<E: FieldElement>(
         layers: Vec<FriProofLayer>,
@@ -34,6 +37,14 @@ impl FriProof {
             remainder: E::elements_as_bytes(&remainder).to_vec(),
             num_partitions: num_partitions.trailing_zeros() as u8,
         }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the number of layers in this FRI proof.
+    pub fn num_layers(&self) -> usize {
+        self.layers.len()
     }
 
     /// Returns the number of partitions used during proof generation.
@@ -88,10 +99,54 @@ impl FriProof {
 
     /// Returns a vector of remainder values (last FRI layer)
     pub fn parse_remainder<E: FieldElement>(&self) -> Result<Vec<E>, ProofSerializationError> {
-        let remainder = read_elements_into_vec(&self.remainder).map_err(|err| {
-            ProofSerializationError::RemainderDeserializationError(err.to_string())
-        })?;
+        let remainder = read_elements_into_vec(&self.remainder)
+            .map_err(|err| ProofSerializationError::RemainderParsingError(err.to_string()))?;
         Ok(remainder)
+    }
+
+    // SERIALIZATION
+    // --------------------------------------------------------------------------------------------
+
+    /// Serializes this FRI proof and writes it into the specified target vector. Proof bytes are
+    /// appended at the end of the vector.
+    pub fn write_into(&self, target: &mut Vec<u8>) {
+        // write layers
+        target.push(self.layers.len() as u8);
+        for layer in self.layers.iter() {
+            layer.write_into(target);
+        }
+
+        // write remainder
+        target.push(self.remainder.len().trailing_zeros() as u8);
+        target.extend_from_slice(&self.remainder);
+
+        // write number of partitions
+        target.push(self.num_partitions);
+    }
+
+    /// Reads a FRI proof from the specified source starting at the specified position. Returns
+    /// an error if a valid proof could not be read from the source.
+    pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
+        // read layers
+        let num_layers = read_u8(source, pos)? as usize;
+        let mut layers = Vec::new();
+        for _ in 0..num_layers {
+            let layer = FriProofLayer::read_from(source, pos)?;
+            layers.push(layer);
+        }
+
+        // read remainder
+        let remainder_bytes = 2usize.pow(read_u8(source, pos)? as u32);
+        let remainder = read_u8_vec(source, pos, remainder_bytes)?;
+
+        // read number of partitions
+        let num_partitions = read_u8(source, pos)?;
+
+        Ok(FriProof {
+            layers,
+            remainder,
+            num_partitions,
+        })
     }
 }
 
@@ -144,7 +199,7 @@ impl FriProofLayer {
         // make sure the number of value bytes can be parsed into a whole number of queries
         let num_query_bytes = E::ELEMENT_BYTES * folding_factor;
         if self.values.len() % num_query_bytes != 0 {
-            return Err(ProofSerializationError::LayerDeserializationError(
+            return Err(ProofSerializationError::LayerParsingError(
                 layer_depth,
                 format!(
                     "number of value bytes ({}) does not divide into whole number of queries",
@@ -165,7 +220,7 @@ impl FriProofLayer {
             .zip(hashed_queries.iter_mut())
         {
             let mut qe = read_elements_into_vec::<E>(query_bytes).map_err(|err| {
-                ProofSerializationError::LayerDeserializationError(layer_depth, err.to_string())
+                ProofSerializationError::LayerParsingError(layer_depth, err.to_string())
             })?;
             *query_hash = H::hash_elements(&qe);
             query_values.append(&mut qe);
@@ -175,9 +230,35 @@ impl FriProofLayer {
         let tree_depth = log2(domain_size) as u8;
         let merkle_proof = BatchMerkleProof::deserialize(&self.paths, hashed_queries, tree_depth)
             .map_err(|err| {
-            ProofSerializationError::LayerDeserializationError(layer_depth, err.to_string())
+            ProofSerializationError::LayerParsingError(layer_depth, err.to_string())
         })?;
 
         Ok((query_values, merkle_proof))
+    }
+
+    /// Writes this layer into the provided vector of bytes. Layer bytes are appended at the
+    /// end of the vector.
+    pub fn write_into(&self, target: &mut Vec<u8>) {
+        // write value bytes
+        target.extend_from_slice(&(self.values.len() as u32).to_le_bytes());
+        target.extend_from_slice(&self.values);
+
+        // write path bytes
+        target.extend_from_slice(&(self.paths.len() as u32).to_le_bytes());
+        target.extend_from_slice(&self.paths);
+    }
+
+    /// Reads a single proof layer form the specified source starting at the specified position.
+    /// Returns an error if a valid layer could not be read from the source.
+    pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
+        // read values
+        let num_value_bytes = read_u32(source, pos)?;
+        let values = read_u8_vec(source, pos, num_value_bytes as usize)?;
+
+        // read paths
+        let num_paths_bytes = read_u32(source, pos)?;
+        let paths = read_u8_vec(source, pos, num_paths_bytes as usize)?;
+
+        Ok(FriProofLayer { values, paths })
     }
 }

--- a/fri/src/prover/tests.rs
+++ b/fri/src/prover/tests.rs
@@ -48,6 +48,14 @@ pub fn verify_proof(
     positions: &[usize],
     options: &FriOptions,
 ) -> Result<(), VerifierError> {
+    // test proof serialization / deserialization
+    let mut proof_bytes = Vec::new();
+    proof.write_into(&mut proof_bytes);
+
+    let mut pos = 0;
+    let proof = FriProof::read_from(&proof_bytes, &mut pos).unwrap();
+
+    // verify the proof
     let mut channel = DefaultVerifierChannel::<BaseElement, hash::Blake3_256>::new(
         proof,
         domain_size,

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -31,7 +31,6 @@ concurrent = ["rayon"]
 [dependencies]
 utils = { path = "../utils", package = "winter-utils" }
 rayon = { version = "1.5", optional = true }
-serde = { version = "1.0", features = ["derive"] }
 rand = "0.8"
 
 

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -16,7 +16,6 @@ use core::{
     slice,
 };
 use rand::{distributions::Uniform, prelude::*};
-use serde::{Deserialize, Serialize};
 use utils::{AsBytes, Serializable};
 
 #[cfg(test)]
@@ -39,8 +38,7 @@ const ELEMENT_BYTES: usize = std::mem::size_of::<u128>();
 // FIELD ELEMENT
 // ================================================================================================
 
-// TODO: get rid of Serialize and Deserialize derives
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub struct BaseElement(u128);
 
 impl BaseElement {

--- a/utils/src/errors.rs
+++ b/utils/src/errors.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use core::fmt;
+
+// DESERIALIZATION ERROR
+// ================================================================================================
+
+#[derive(Debug, PartialEq)]
+pub enum DeserializationError {
+    /// Unexpected EOF
+    UnexpectedEOF,
+    /// Unknown error: {0}
+    UnknownError(String),
+}
+
+impl fmt::Display for DeserializationError {
+    #[rustfmt::skip]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnexpectedEOF => {
+                write!(f, "unexpected EOF")
+            }
+            Self::UnknownError(err_msg) => {
+                write!(f, "unknown error: {}", err_msg)
+            }
+        }
+    }
+}

--- a/utils/src/errors.rs
+++ b/utils/src/errors.rs
@@ -10,6 +10,8 @@ use core::fmt;
 
 #[derive(Debug, PartialEq)]
 pub enum DeserializationError {
+    /// Value {0} cannot be deserialized as {}
+    InvalidValue(String, String),
     /// Unexpected EOF
     UnexpectedEOF,
     /// Unknown error: {0}
@@ -20,6 +22,9 @@ impl fmt::Display for DeserializationError {
     #[rustfmt::skip]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::InvalidValue(value, type_name) => {
+                write!(f, "value {} cannot be deserialized as {}", value, type_name)
+            }
             Self::UnexpectedEOF => {
                 write!(f, "unexpected EOF")
             }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -182,7 +182,7 @@ pub fn read_u8(source: &[u8], pos: &mut usize) -> Result<u8, DeserializationErro
 
 /// Reads a u16 value from the specified source starting at the specified position, and increments
 /// `pos` by two. The u16 value is assumed to be in little-endian byte order.
-/// Returns an error if the u16 value could not be read from the specified source.
+/// Returns an error if a u16 value could not be read from the specified source.
 pub fn read_u16(source: &[u8], pos: &mut usize) -> Result<u16, DeserializationError> {
     let end_pos = *pos + 2;
     if end_pos > source.len() {
@@ -201,7 +201,7 @@ pub fn read_u16(source: &[u8], pos: &mut usize) -> Result<u16, DeserializationEr
 
 /// Reads a u32 value from the specified source starting at the specified position, and increments
 /// `pos` by four. The u32 value is assumed to be in little-endian byte order.
-/// Returns an error if the u32 value could not be read from the specified source.
+/// Returns an error if a u32 value could not be read from the specified source.
 pub fn read_u32(source: &[u8], pos: &mut usize) -> Result<u32, DeserializationError> {
     let end_pos = *pos + 4;
     if end_pos > source.len() {
@@ -209,6 +209,25 @@ pub fn read_u32(source: &[u8], pos: &mut usize) -> Result<u32, DeserializationEr
     }
 
     let result = u32::from_le_bytes(
+        source[*pos..end_pos]
+            .try_into()
+            .map_err(|err| DeserializationError::UnknownError(format!("{}", err)))?,
+    );
+
+    *pos = end_pos;
+    Ok(result)
+}
+
+/// Reads a u64 value from the specified source starting at the specified position, and increments
+/// `pos` by eight. The u64 value is assumed to be in little-endian byte order.
+/// Returns an error if a u64 value could not be read from the specified source.
+pub fn read_u64(source: &[u8], pos: &mut usize) -> Result<u64, DeserializationError> {
+    let end_pos = *pos + 8;
+    if end_pos > source.len() {
+        return Err(DeserializationError::UnexpectedEOF);
+    }
+
+    let result = u64::from_le_bytes(
         source[*pos..end_pos]
             .try_into()
             .map_err(|err| DeserializationError::UnknownError(format!("{}", err)))?,

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -3,9 +3,12 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use core::{mem, slice};
+use core::{convert::TryInto, mem, slice};
 
 mod iterators;
+
+mod errors;
+pub use errors::DeserializationError;
 
 #[cfg(test)]
 mod tests;
@@ -160,4 +163,74 @@ pub fn transpose_slice<T: Copy + Send + Sync, const N: usize>(source: &[T]) -> V
             }
         });
     result
+}
+
+// DESERIALIZER FUNCTIONS
+// ================================================================================================
+
+/// Reads a byte from the specified source at the specified position, and increments `pos` by one.
+/// Returns an error if `pos` is out of bounds.
+pub fn read_u8(source: &[u8], pos: &mut usize) -> Result<u8, DeserializationError> {
+    if *pos >= source.len() {
+        return Err(DeserializationError::UnexpectedEOF);
+    }
+    let result = source[*pos];
+
+    *pos += 1;
+    Ok(result)
+}
+
+/// Reads a u16 value from the specified source starting at the specified position, and increments
+/// `pos` by two. The u16 value is assumed to be in little-endian byte order.
+/// Returns an error if the u16 value could not be read from the specified source.
+pub fn read_u16(source: &[u8], pos: &mut usize) -> Result<u16, DeserializationError> {
+    let end_pos = *pos + 2;
+    if end_pos > source.len() {
+        return Err(DeserializationError::UnexpectedEOF);
+    }
+
+    let result = u16::from_le_bytes(
+        source[*pos..end_pos]
+            .try_into()
+            .map_err(|err| DeserializationError::UnknownError(format!("{}", err)))?,
+    );
+
+    *pos = end_pos;
+    Ok(result)
+}
+
+/// Reads a u32 value from the specified source starting at the specified position, and increments
+/// `pos` by four. The u32 value is assumed to be in little-endian byte order.
+/// Returns an error if the u32 value could not be read from the specified source.
+pub fn read_u32(source: &[u8], pos: &mut usize) -> Result<u32, DeserializationError> {
+    let end_pos = *pos + 4;
+    if end_pos > source.len() {
+        return Err(DeserializationError::UnexpectedEOF);
+    }
+
+    let result = u32::from_le_bytes(
+        source[*pos..end_pos]
+            .try_into()
+            .map_err(|err| DeserializationError::UnknownError(format!("{}", err)))?,
+    );
+
+    *pos = end_pos;
+    Ok(result)
+}
+
+/// Reads a byte vector of specified from the specified source starting at the specified
+/// position, and increments `pos` by the length of the vector.
+/// Returns an error if a vector of the specified length could not be read from the source.
+pub fn read_u8_vec(
+    source: &[u8],
+    pos: &mut usize,
+    len: usize,
+) -> Result<Vec<u8>, DeserializationError> {
+    let end_pos = *pos + len as usize;
+    if end_pos > source.len() {
+        return Err(DeserializationError::UnexpectedEOF);
+    }
+    let result = source[*pos..end_pos].to_vec();
+    *pos = end_pos;
+    Ok(result)
 }

--- a/utils/src/tests.rs
+++ b/utils/src/tests.rs
@@ -92,6 +92,22 @@ fn read_u32() {
 }
 
 #[test]
+fn read_u64() {
+    let mut a = 12345678910u64.to_le_bytes().to_vec();
+    a.append(&mut 234567891011u64.to_le_bytes().to_vec());
+
+    let mut pos = 0;
+    assert_eq!(12345678910, super::read_u64(&a, &mut pos).unwrap());
+    assert_eq!(8, pos);
+
+    assert_eq!(234567891011, super::read_u64(&a, &mut pos).unwrap());
+    assert_eq!(16, pos);
+
+    pos = 14;
+    assert!(super::read_u64(&a, &mut pos).is_err());
+}
+
+#[test]
 fn read_u8_vec() {
     let a = [1u8, 2, 3, 4, 5, 6, 7, 8];
 

--- a/utils/src/tests.rs
+++ b/utils/src/tests.rs
@@ -39,3 +39,74 @@ fn transpose_slice() {
 
     assert_eq!([[0, 4], [1, 5], [2, 6], [3, 7]].to_vec(), b);
 }
+
+// DESERIALIZATION TESTS
+// ================================================================================================
+
+#[test]
+fn read_u8() {
+    let a = [1u8, 3, 5, 7];
+
+    let mut pos = 0;
+    assert_eq!(1, super::read_u8(&a, &mut pos).unwrap());
+    assert_eq!(1, pos);
+
+    pos += 1;
+    assert_eq!(5, super::read_u8(&a, &mut pos).unwrap());
+    assert_eq!(3, pos);
+
+    pos = 4;
+    assert!(super::read_u8(&a, &mut pos).is_err());
+}
+
+#[test]
+fn read_u16() {
+    let mut a = 12345u16.to_le_bytes().to_vec();
+    a.append(&mut 23456u16.to_le_bytes().to_vec());
+
+    let mut pos = 0;
+    assert_eq!(12345, super::read_u16(&a, &mut pos).unwrap());
+    assert_eq!(2, pos);
+
+    assert_eq!(23456, super::read_u16(&a, &mut pos).unwrap());
+    assert_eq!(4, pos);
+
+    pos = 3;
+    assert!(super::read_u16(&a, &mut pos).is_err());
+}
+
+#[test]
+fn read_u32() {
+    let mut a = 123456789u32.to_le_bytes().to_vec();
+    a.append(&mut 2345678910u32.to_le_bytes().to_vec());
+
+    let mut pos = 0;
+    assert_eq!(123456789, super::read_u32(&a, &mut pos).unwrap());
+    assert_eq!(4, pos);
+
+    assert_eq!(2345678910, super::read_u32(&a, &mut pos).unwrap());
+    assert_eq!(8, pos);
+
+    pos = 6;
+    assert!(super::read_u32(&a, &mut pos).is_err());
+}
+
+#[test]
+fn read_u8_vec() {
+    let a = [1u8, 2, 3, 4, 5, 6, 7, 8];
+
+    let mut pos = 0;
+    assert_eq!(vec![1, 2], super::read_u8_vec(&a, &mut pos, 2).unwrap());
+    assert_eq!(2, pos);
+
+    assert_eq!(vec![3, 4, 5], super::read_u8_vec(&a, &mut pos, 3).unwrap());
+    assert_eq!(5, pos);
+
+    assert_eq!(vec![6, 7], super::read_u8_vec(&a, &mut pos, 2).unwrap());
+    assert_eq!(7, pos);
+
+    assert_eq!(vec![8], super::read_u8_vec(&a, &mut pos, 1).unwrap());
+
+    pos = 7;
+    assert!(super::read_u8_vec(&a, &mut pos, 2).is_err());
+}


### PR DESCRIPTION
This PR addresses #7 but since a few other PRs already implemented the bulk of proof serialization optimizations (e.g. #15 and #16), the actual impact of this PR on proof size is negligible.

However, it does allow us to get rid of `serde` dependencies reducing total number of direct external dependencies to 5: `blake3`, `sha3`, `log` (for prover only), `rayon` (for concurrent prover only), `rand` (not really needed).

- [x] Implement custom proof serialization
- [x] Remove `serde` (and `bincode`) dependency
- [x] Update benchmarks