### PR TITLE
Utils crate refactoring + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ For more information about the `Air` trait see [common crate](common#Air-trait),
 ```Rust
 use math::field::{f128::BaseElement, FieldElement};
 use prover::{
-    Air, Assertion, ComputationContext, EvaluationFrame, ProofOptions, Serializable,
-    TraceInfo, TransitionConstraintDegree,
+    Air, Assertion, ByteWriter, ComputationContext, EvaluationFrame, ProofOptions,
+    Serializable, TraceInfo, TransitionConstraintDegree,
 };
 
 // Public inputs for our computation will consist of the starting value and the end result.
@@ -138,9 +138,9 @@ pub struct PublicInputs {
 
 // We need to describe how public inputs can be converted to bytes.
 impl Serializable for PublicInputs {
-    fn write_into(&self, target: &mut Vec<u8>) {
-        self.start.write_into(target);
-        self.result.write_into(target);
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write(self.start);
+        target.write(self.result);
     }
 }
 

--- a/common/src/options.rs
+++ b/common/src/options.rs
@@ -5,7 +5,7 @@
 
 use fri::FriOptions;
 use math::field::StarkField;
-use utils::{ByteReader, DeserializationError};
+use utils::{ByteReader, ByteWriter, DeserializationError};
 
 // TYPES AND INTERFACES
 // ================================================================================================
@@ -145,21 +145,24 @@ impl ProofOptions {
     // SERIALIZATION / DESERIALIZATION
     // --------------------------------------------------------------------------------------------
 
-    /// Serializes these options and appends the resulting bytes to the `target` vector.
-    pub fn write_into(&self, target: &mut Vec<u8>) {
-        target.push(self.num_queries);
-        target.push(self.blowup_factor);
-        target.push(self.grinding_factor);
-        target.push(self.hash_fn as u8);
-        target.push(self.field_extension as u8);
-        target.push(self.fri_folding_factor);
-        target.push(self.fri_max_remainder_size);
+    /// Serializes `self` and writes the resulting bytes into the `target` writer.
+    pub fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_u8(self.num_queries);
+        target.write_u8(self.blowup_factor);
+        target.write_u8(self.grinding_factor);
+        self.hash_fn.write_into(target);
+        self.field_extension.write_into(target);
+        target.write_u8(self.fri_folding_factor);
+        target.write_u8(self.fri_max_remainder_size);
     }
 
     /// Reads proof options from the specified source starting at the specified position and
     /// increments `pos` to point to a position right after the end of read-in option bytes.
     /// Returns an error of a valid proof options could not be read from the specified source.
-    pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
+    pub fn read_from<R: ByteReader>(
+        source: &R,
+        pos: &mut usize,
+    ) -> Result<Self, DeserializationError> {
         Ok(ProofOptions::new(
             source.read_u8(pos)? as usize,
             source.read_u8(pos)? as usize,
@@ -189,9 +192,17 @@ impl FieldExtension {
         }
     }
 
+    /// Serializes `self` and writes the resulting bytes into the `target` writer.
+    pub fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_u8(*self as u8);
+    }
+
     /// Reads a field extension enum from the byte at the specified position and increments
     /// `pos` by one.
-    pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
+    pub fn read_from<R: ByteReader>(
+        source: &R,
+        pos: &mut usize,
+    ) -> Result<Self, DeserializationError> {
         match source.read_u8(pos)? {
             1 => Ok(FieldExtension::None),
             2 => Ok(FieldExtension::Quadratic),
@@ -215,9 +226,17 @@ impl HashFunction {
         }
     }
 
-    /// Reads a hash function enum from the byte at the specified position and increments
+    /// Serializes `self` and writes the resulting bytes into the `target` writer.
+    pub fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_u8(*self as u8);
+    }
+
+    /// Reads a hash function enum from the reader at the specified position and increments
     /// `pos` by one.
-    pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
+    pub fn read_from<R: ByteReader>(
+        source: &R,
+        pos: &mut usize,
+    ) -> Result<Self, DeserializationError> {
         match source.read_u8(pos)? {
             1 => Ok(HashFunction::Blake3_256),
             2 => Ok(HashFunction::Sha3_256),

--- a/common/src/options.rs
+++ b/common/src/options.rs
@@ -5,7 +5,7 @@
 
 use fri::FriOptions;
 use math::field::StarkField;
-use utils::{read_u8, DeserializationError};
+use utils::{ByteReader, DeserializationError};
 
 // TYPES AND INTERFACES
 // ================================================================================================
@@ -161,13 +161,13 @@ impl ProofOptions {
     /// Returns an error of a valid proof options could not be read from the specified source.
     pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
         Ok(ProofOptions::new(
-            read_u8(source, pos)? as usize,
-            read_u8(source, pos)? as usize,
-            read_u8(source, pos)? as u32,
+            source.read_u8(pos)? as usize,
+            source.read_u8(pos)? as usize,
+            source.read_u8(pos)? as u32,
             HashFunction::read_from(source, pos)?,
             FieldExtension::read_from(source, pos)?,
-            read_u8(source, pos)? as usize,
-            2usize.pow(read_u8(source, pos)? as u32),
+            source.read_u8(pos)? as usize,
+            2usize.pow(source.read_u8(pos)? as u32),
         ))
     }
 }
@@ -192,7 +192,7 @@ impl FieldExtension {
     /// Reads a field extension enum from the byte at the specified position and increments
     /// `pos` by one.
     pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
-        match read_u8(source, pos)? {
+        match source.read_u8(pos)? {
             1 => Ok(FieldExtension::None),
             2 => Ok(FieldExtension::Quadratic),
             value => Err(DeserializationError::InvalidValue(
@@ -218,7 +218,7 @@ impl HashFunction {
     /// Reads a hash function enum from the byte at the specified position and increments
     /// `pos` by one.
     pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
-        match read_u8(source, pos)? {
+        match source.read_u8(pos)? {
             1 => Ok(HashFunction::Blake3_256),
             2 => Ok(HashFunction::Sha3_256),
             value => Err(DeserializationError::InvalidValue(

--- a/common/src/proof/commitments.rs
+++ b/common/src/proof/commitments.rs
@@ -5,7 +5,7 @@
 
 use crate::errors::ProofSerializationError;
 use crypto::Hasher;
-use utils::{read_u16, read_u8_vec, DeserializationError};
+use utils::{ByteReader, DeserializationError};
 
 // COMMITMENTS
 // ================================================================================================
@@ -76,8 +76,8 @@ impl Commitments {
     /// increments `pos` to point to a position right after the end of read-in commitment bytes.
     /// Returns an error of a valid Commitments struct could not be read from the specified source.
     pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
-        let num_bytes = read_u16(source, pos)? as usize;
-        let result = read_u8_vec(source, pos, num_bytes)?;
+        let num_bytes = source.read_u16(pos)? as usize;
+        let result = source.read_u8_vec(pos, num_bytes)?;
         Ok(Commitments(result))
     }
 }

--- a/common/src/proof/context.rs
+++ b/common/src/proof/context.rs
@@ -5,7 +5,7 @@
 
 use crate::ProofOptions;
 use math::{field::StarkField, utils::log2};
-use utils::{read_u8, read_u8_vec, DeserializationError};
+use utils::{ByteReader, DeserializationError};
 
 // PROOF HEADER
 // ================================================================================================
@@ -84,9 +84,9 @@ impl Context {
     /// increments `pos` to point to a position right after the end of read-in context bytes.
     /// Returns an error of a valid Context struct could not be read from the specified source.
     pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
-        let lde_domain_depth = read_u8(source, pos)?;
-        let num_modulus_bytes = read_u8(source, pos)? as usize;
-        let field_modulus_bytes = read_u8_vec(source, pos, num_modulus_bytes)?;
+        let lde_domain_depth = source.read_u8(pos)?;
+        let num_modulus_bytes = source.read_u8(pos)? as usize;
+        let field_modulus_bytes = source.read_u8_vec(pos, num_modulus_bytes)?;
         let options = ProofOptions::read_from(source, pos)?;
 
         Ok(Context {

--- a/common/src/proof/mod.rs
+++ b/common/src/proof/mod.rs
@@ -96,7 +96,7 @@ impl StarkProof {
 
     /// Returns a STARK proof read from the specified source starting at position 0.
     /// Returns an error of a valid STARK proof could not be read from the specified source.
-    pub fn from_bytes(source: &[u8]) -> Result<Self, DeserializationError> {
+    pub fn from_bytes<R: ByteReader>(source: &R) -> Result<Self, DeserializationError> {
         let mut pos = 0;
         Ok(StarkProof {
             context: Context::read_from(source, &mut pos)?,

--- a/common/src/proof/mod.rs
+++ b/common/src/proof/mod.rs
@@ -7,7 +7,7 @@ use crate::ProofOptions;
 use core::cmp;
 use fri::FriProof;
 use math::utils::log2;
-use utils::{read_u64, DeserializationError};
+use utils::{ByteReader, DeserializationError};
 
 mod context;
 pub use context::Context;
@@ -105,7 +105,7 @@ impl StarkProof {
             constraint_queries: Queries::read_from(source, &mut pos)?,
             ood_frame: OodFrame::read_from(source, &mut pos)?,
             fri_proof: FriProof::read_from(source, &mut pos)?,
-            pow_nonce: read_u64(source, &mut pos)?,
+            pow_nonce: source.read_u64(&mut pos)?,
         })
     }
 }

--- a/common/src/proof/ood_frame.rs
+++ b/common/src/proof/ood_frame.rs
@@ -5,7 +5,7 @@
 
 use crate::{errors::ProofSerializationError, EvaluationFrame};
 use math::{field::FieldElement, utils::read_elements_into_vec};
-use utils::{read_u16, read_u8_vec, DeserializationError};
+use utils::{ByteReader, DeserializationError};
 
 // OUT-OF-DOMAIN EVALUATION FRAME
 // ================================================================================================
@@ -104,13 +104,13 @@ impl OodFrame {
     /// Returns an error of a valid OOD frame could not be read from the specified source.
     pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
         // read trace rows
-        let trace_row_bytes = read_u16(source, pos)? as usize;
-        let trace_at_z1 = read_u8_vec(source, pos, trace_row_bytes)?;
-        let trace_at_z2 = read_u8_vec(source, pos, trace_row_bytes)?;
+        let trace_row_bytes = source.read_u16(pos)? as usize;
+        let trace_at_z1 = source.read_u8_vec(pos, trace_row_bytes)?;
+        let trace_at_z2 = source.read_u8_vec(pos, trace_row_bytes)?;
 
         // read constraint evaluations row
-        let constraint_row_bytes = read_u16(source, pos)? as usize;
-        let evaluations = read_u8_vec(source, pos, constraint_row_bytes)?;
+        let constraint_row_bytes = source.read_u16(pos)? as usize;
+        let evaluations = source.read_u8_vec(pos, constraint_row_bytes)?;
 
         Ok(OodFrame {
             trace_at_z1,

--- a/common/src/proof/ood_frame.rs
+++ b/common/src/proof/ood_frame.rs
@@ -5,7 +5,7 @@
 
 use crate::{errors::ProofSerializationError, EvaluationFrame};
 use math::{field::FieldElement, utils::read_elements_into_vec};
-use utils::{ByteReader, DeserializationError};
+use utils::{ByteReader, ByteWriter, DeserializationError};
 
 // OUT-OF-DOMAIN EVALUATION FRAME
 // ================================================================================================
@@ -87,22 +87,25 @@ impl OodFrame {
     // SERIALIZATION / DESERIALIZATION
     // --------------------------------------------------------------------------------------------
 
-    /// Serializes this out-of-domain frame and appends the resulting bytes to the `target` vector.
-    pub fn write_into(&self, target: &mut Vec<u8>) {
+    /// Serializes `self` and writes the resulting bytes into the `target` writer.
+    pub fn write_into<W: ByteWriter>(&self, target: &mut W) {
         // write trace rows (both rows have the same number of bytes)
-        target.extend_from_slice(&(self.trace_at_z1.len() as u16).to_le_bytes());
-        target.extend_from_slice(&self.trace_at_z1);
-        target.extend_from_slice(&self.trace_at_z2);
+        target.write_u16(self.trace_at_z1.len() as u16);
+        target.write_u8_slice(&self.trace_at_z1);
+        target.write_u8_slice(&self.trace_at_z2);
 
         // write constraint evaluations row
-        target.extend_from_slice(&(self.evaluations.len() as u16).to_le_bytes());
-        target.extend_from_slice(&self.evaluations)
+        target.write_u16(self.evaluations.len() as u16);
+        target.write_u8_slice(&self.evaluations)
     }
 
     /// Reads a OOD frame from the specified source starting at the specified position and
     /// increments `pos` to point to a position right after the end of read-in frame bytes.
     /// Returns an error of a valid OOD frame could not be read from the specified source.
-    pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
+    pub fn read_from<R: ByteReader>(
+        source: &R,
+        pos: &mut usize,
+    ) -> Result<Self, DeserializationError> {
         // read trace rows
         let trace_row_bytes = source.read_u16(pos)? as usize;
         let trace_at_z1 = source.read_u8_vec(pos, trace_row_bytes)?;

--- a/common/src/proof/queries.rs
+++ b/common/src/proof/queries.rs
@@ -9,7 +9,7 @@ use math::{
     field::FieldElement,
     utils::{log2, read_elements_into_vec},
 };
-use utils::{read_u32, read_u8_vec, DeserializationError};
+use utils::{ByteReader, DeserializationError};
 
 // QUERIES
 // ================================================================================================
@@ -132,12 +132,12 @@ impl Queries {
     /// Returns an error of a valid query struct could not be read from the specified source.
     pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
         // read values
-        let num_value_bytes = read_u32(source, pos)?;
-        let values = read_u8_vec(source, pos, num_value_bytes as usize)?;
+        let num_value_bytes = source.read_u32(pos)?;
+        let values = source.read_u8_vec(pos, num_value_bytes as usize)?;
 
         // read paths
-        let num_paths_bytes = read_u32(source, pos)?;
-        let paths = read_u8_vec(source, pos, num_paths_bytes as usize)?;
+        let num_paths_bytes = source.read_u32(pos)?;
+        let paths = source.read_u8_vec(pos, num_paths_bytes as usize)?;
 
         Ok(Queries { paths, values })
     }

--- a/common/src/proof/queries.rs
+++ b/common/src/proof/queries.rs
@@ -9,7 +9,7 @@ use math::{
     field::FieldElement,
     utils::{log2, read_elements_into_vec},
 };
-use utils::{ByteReader, DeserializationError};
+use utils::{ByteReader, ByteWriter, DeserializationError};
 
 // QUERIES
 // ================================================================================================
@@ -116,21 +116,24 @@ impl Queries {
     // SERIALIZATION / DESERIALIZATION
     // --------------------------------------------------------------------------------------------
 
-    /// Serializes this queries struct and appends the resulting bytes to the `target` vector.
-    pub fn write_into(&self, target: &mut Vec<u8>) {
+    /// Serializes `self` and writes the resulting bytes into the `target` writer.
+    pub fn write_into<W: ByteWriter>(&self, target: &mut W) {
         // write value bytes
-        target.extend_from_slice(&(self.values.len() as u32).to_le_bytes());
-        target.extend_from_slice(&self.values);
+        target.write_u32(self.values.len() as u32);
+        target.write_u8_slice(&self.values);
 
         // write path bytes
-        target.extend_from_slice(&(self.paths.len() as u32).to_le_bytes());
-        target.extend_from_slice(&self.paths);
+        target.write_u32(self.paths.len() as u32);
+        target.write_u8_slice(&self.paths);
     }
 
     /// Reads a query struct from the specified source starting at the specified position and
     /// increments `pos` to point to a position right after the end of read-in query bytes.
     /// Returns an error of a valid query struct could not be read from the specified source.
-    pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
+    pub fn read_from<R: ByteReader>(
+        source: &R,
+        pos: &mut usize,
+    ) -> Result<Self, DeserializationError> {
         // read values
         let num_value_bytes = source.read_u32(pos)?;
         let values = source.read_u8_vec(pos, num_value_bytes as usize)?;

--- a/crypto/benches/merkle.rs
+++ b/crypto/benches/merkle.rs
@@ -17,7 +17,7 @@ pub fn merkle_tree_construction(c: &mut Criterion) {
         let mut csprng: ThreadRng = thread_rng();
 
         let data: Vec<[u8; 32]> = {
-            let mut res = uninit_vector(*size);
+            let mut res = unsafe { uninit_vector(*size) };
             for i in 0..*size {
                 let mut v = [0u8; 32];
                 csprng.fill_bytes(&mut v);

--- a/crypto/src/merkle/concurrent.rs
+++ b/crypto/src/merkle/concurrent.rs
@@ -22,7 +22,7 @@ pub fn build_merkle_nodes<H: Hasher>(leaves: &[H::Digest]) -> Vec<H::Digest> {
     let n = leaves.len() / 2;
 
     // create un-initialized array to hold all intermediate nodes
-    let mut nodes = utils::uninit_vector::<H::Digest>(2 * n);
+    let mut nodes = unsafe { utils::uninit_vector::<H::Digest>(2 * n) };
     nodes[0] = H::Digest::default();
 
     // re-interpret leaves as an array of two leaves fused together and use it to

--- a/crypto/src/merkle/mod.rs
+++ b/crypto/src/merkle/mod.rs
@@ -186,7 +186,7 @@ pub fn build_merkle_nodes<H: Hasher>(leaves: &[H::Digest]) -> Vec<H::Digest> {
     let n = leaves.len() / 2;
 
     // create un-initialized array to hold all intermediate nodes
-    let mut nodes = utils::uninit_vector::<H::Digest>(2 * n);
+    let mut nodes = unsafe { utils::uninit_vector::<H::Digest>(2 * n) };
     nodes[0] = H::Digest::default();
 
     // re-interpret leaves as an array of two leaves fused together

--- a/examples/src/lamport/aggregate/air.rs
+++ b/examples/src/lamport/aggregate/air.rs
@@ -9,8 +9,8 @@ use super::{
 use crate::utils::{are_equal, is_binary, is_zero, not, EvaluationResult};
 use prover::{
     math::field::{f128::BaseElement, FieldElement},
-    Air, Assertion, ComputationContext, EvaluationFrame, ProofOptions, Serializable, TraceInfo,
-    TransitionConstraintDegree,
+    Air, Assertion, ByteWriter, ComputationContext, EvaluationFrame, ProofOptions, Serializable,
+    TraceInfo, TransitionConstraintDegree,
 };
 
 // CONSTANTS
@@ -26,9 +26,9 @@ pub struct PublicInputs {
 }
 
 impl Serializable for PublicInputs {
-    fn write_into(&self, target: &mut Vec<u8>) {
-        BaseElement::write_array_batch_into(&self.pub_keys, target);
-        BaseElement::write_array_batch_into(&self.messages, target);
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_table(&self.pub_keys);
+        target.write_table(&self.messages);
     }
 }
 

--- a/examples/src/lamport/threshold/air.rs
+++ b/examples/src/lamport/threshold/air.rs
@@ -13,8 +13,8 @@ use prover::{
         field::{f128::BaseElement, FieldElement, StarkField},
         utils::log2,
     },
-    Air, Assertion, ComputationContext, EvaluationFrame, ProofOptions, Serializable, TraceInfo,
-    TransitionConstraintDegree,
+    Air, Assertion, ByteWriter, ComputationContext, EvaluationFrame, ProofOptions, Serializable,
+    TraceInfo, TransitionConstraintDegree,
 };
 
 // CONSTANTS
@@ -32,11 +32,11 @@ pub struct PublicInputs {
 }
 
 impl Serializable for PublicInputs {
-    fn write_into(&self, target: &mut Vec<u8>) {
-        BaseElement::write_batch_into(&self.pub_key_root, target);
-        target.extend_from_slice(&(self.num_pub_keys as u32).to_le_bytes());
-        target.extend_from_slice(&(self.num_signatures as u32).to_le_bytes());
-        BaseElement::write_batch_into(&self.message, target);
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_slice(&self.pub_key_root);
+        target.write_u32(self.num_pub_keys as u32);
+        target.write_u32(self.num_signatures as u32);
+        target.write_slice(&self.message);
     }
 }
 

--- a/examples/src/merkle/air.rs
+++ b/examples/src/merkle/air.rs
@@ -13,7 +13,7 @@ use crate::utils::{
 };
 use prover::{
     math::field::{f128::BaseElement, FieldElement},
-    Air, Assertion, ComputationContext, EvaluationFrame, ExecutionTrace, ProofOptions,
+    Air, Assertion, ByteWriter, ComputationContext, EvaluationFrame, ExecutionTrace, ProofOptions,
     Serializable, TraceInfo, TransitionConstraintDegree,
 };
 
@@ -30,8 +30,8 @@ pub struct PublicInputs {
 }
 
 impl Serializable for PublicInputs {
-    fn write_into(&self, target: &mut Vec<u8>) {
-        BaseElement::write_batch_into(&self.tree_root, target);
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_slice(&self.tree_root);
     }
 }
 

--- a/examples/src/rescue/air.rs
+++ b/examples/src/rescue/air.rs
@@ -7,7 +7,7 @@ use super::rescue;
 use crate::utils::{are_equal, is_zero, not, EvaluationResult};
 use prover::{
     math::field::{f128::BaseElement, FieldElement},
-    Air, Assertion, ComputationContext, EvaluationFrame, ExecutionTrace, ProofOptions,
+    Air, Assertion, ByteWriter, ComputationContext, EvaluationFrame, ExecutionTrace, ProofOptions,
     Serializable, TraceInfo, TransitionConstraintDegree,
 };
 
@@ -47,9 +47,9 @@ pub struct PublicInputs {
 }
 
 impl Serializable for PublicInputs {
-    fn write_into(&self, target: &mut Vec<u8>) {
-        BaseElement::write_batch_into(&self.seed, target);
-        BaseElement::write_batch_into(&self.result, target);
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_slice(&self.seed);
+        target.write_slice(&self.result);
     }
 }
 

--- a/fri/src/folding/mod.rs
+++ b/fri/src/folding/mod.rs
@@ -36,7 +36,7 @@ where
     let inv_twiddles = get_inv_twiddles::<B>(N);
     let len_offset = E::inv((N as u64).into());
 
-    let mut result = uninit_vector(values.len());
+    let mut result = unsafe { uninit_vector(values.len()) };
     iter_mut!(result)
         .zip(values)
         .zip(inv_offsets)

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -9,7 +9,7 @@ use math::{
     field::FieldElement,
     utils::{log2, read_elements_into_vec},
 };
-use utils::{read_u32, read_u8, read_u8_vec, DeserializationError};
+use utils::{ByteReader, DeserializationError};
 
 // FRI PROOF
 // ================================================================================================
@@ -123,7 +123,7 @@ impl FriProof {
     /// an error if a valid proof could not be read from the source.
     pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
         // read layers
-        let num_layers = read_u8(source, pos)? as usize;
+        let num_layers = source.read_u8( pos)? as usize;
         let mut layers = Vec::new();
         for _ in 0..num_layers {
             let layer = FriProofLayer::read_from(source, pos)?;
@@ -131,11 +131,11 @@ impl FriProof {
         }
 
         // read remainder
-        let remainder_bytes = 2usize.pow(read_u8(source, pos)? as u32);
-        let remainder = read_u8_vec(source, pos, remainder_bytes)?;
+        let remainder_bytes = 2usize.pow(source.read_u8( pos)? as u32);
+        let remainder = source.read_u8_vec( pos, remainder_bytes)?;
 
         // read number of partitions
-        let num_partitions = read_u8(source, pos)?;
+        let num_partitions = source.read_u8( pos)?;
 
         Ok(FriProof {
             layers,
@@ -255,12 +255,12 @@ impl FriProofLayer {
     /// Returns an error if a valid layer could not be read from the specified source.
     pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
         // read values
-        let num_value_bytes = read_u32(source, pos)?;
-        let values = read_u8_vec(source, pos, num_value_bytes as usize)?;
+        let num_value_bytes = source.read_u32( pos)?;
+        let values = source.read_u8_vec( pos, num_value_bytes as usize)?;
 
         // read paths
-        let num_paths_bytes = read_u32(source, pos)?;
-        let paths = read_u8_vec(source, pos, num_paths_bytes as usize)?;
+        let num_paths_bytes = source.read_u32( pos)?;
+        let paths = source.read_u8_vec( pos, num_paths_bytes as usize)?;
 
         Ok(FriProofLayer { values, paths })
     }

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -9,7 +9,7 @@ use math::{
     field::FieldElement,
     utils::{log2, read_elements_into_vec},
 };
-use utils::{ByteReader, DeserializationError};
+use utils::{ByteReader, ByteWriter, DeserializationError};
 
 // FRI PROOF
 // ================================================================================================
@@ -103,27 +103,30 @@ impl FriProof {
     // SERIALIZATION / DESERIALIZATION
     // --------------------------------------------------------------------------------------------
 
-    /// Serializes this proof and appends the resulting bytes to the `target` vector.
-    pub fn write_into(&self, target: &mut Vec<u8>) {
+    /// Serializes `self` and writes the resulting bytes into the `target` writer.
+    pub fn write_into<W: ByteWriter>(&self, target: &mut W) {
         // write layers
-        target.push(self.layers.len() as u8);
+        target.write_u8(self.layers.len() as u8);
         for layer in self.layers.iter() {
             layer.write_into(target);
         }
 
         // write remainder
-        target.push(self.remainder.len().trailing_zeros() as u8);
-        target.extend_from_slice(&self.remainder);
+        target.write_u8(self.remainder.len().trailing_zeros() as u8);
+        target.write_u8_slice(&self.remainder);
 
         // write number of partitions
-        target.push(self.num_partitions);
+        target.write_u8(self.num_partitions);
     }
 
     /// Reads a FRI proof from the specified source starting at the specified position. Returns
     /// an error if a valid proof could not be read from the source.
-    pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
+    pub fn read_from<R: ByteReader>(
+        source: &R,
+        pos: &mut usize,
+    ) -> Result<Self, DeserializationError> {
         // read layers
-        let num_layers = source.read_u8( pos)? as usize;
+        let num_layers = source.read_u8(pos)? as usize;
         let mut layers = Vec::new();
         for _ in 0..num_layers {
             let layer = FriProofLayer::read_from(source, pos)?;
@@ -131,11 +134,11 @@ impl FriProof {
         }
 
         // read remainder
-        let remainder_bytes = 2usize.pow(source.read_u8( pos)? as u32);
-        let remainder = source.read_u8_vec( pos, remainder_bytes)?;
+        let remainder_bytes = 2usize.pow(source.read_u8(pos)? as u32);
+        let remainder = source.read_u8_vec(pos, remainder_bytes)?;
 
         // read number of partitions
-        let num_partitions = source.read_u8( pos)?;
+        let num_partitions = source.read_u8(pos)?;
 
         Ok(FriProof {
             layers,
@@ -239,28 +242,31 @@ impl FriProofLayer {
     // SERIALIZATION / DESERIALIZATION
     // --------------------------------------------------------------------------------------------
 
-    /// Serializes this proof layer and appends the resulting bytes to the `target` vector.
-    pub fn write_into(&self, target: &mut Vec<u8>) {
+    /// Serializes this proof layer and writes the resulting bytes to the specified `target`.
+    pub fn write_into<W: ByteWriter>(&self, target: &mut W) {
         // write value bytes
-        target.extend_from_slice(&(self.values.len() as u32).to_le_bytes());
-        target.extend_from_slice(&self.values);
+        target.write_u32(self.values.len() as u32);
+        target.write_u8_slice(&self.values);
 
         // write path bytes
-        target.extend_from_slice(&(self.paths.len() as u32).to_le_bytes());
-        target.extend_from_slice(&self.paths);
+        target.write_u32(self.paths.len() as u32);
+        target.write_u8_slice(&self.paths);
     }
 
-    /// Reads a single proof layer form the specified source starting at the specified position,
+    /// Reads a single proof layer form the `source` starting at the specified position,
     /// and increments `pos` to point to a position right after the end of read-in layer bytes.
     /// Returns an error if a valid layer could not be read from the specified source.
-    pub fn read_from(source: &[u8], pos: &mut usize) -> Result<Self, DeserializationError> {
+    pub fn read_from<R: ByteReader>(
+        source: &R,
+        pos: &mut usize,
+    ) -> Result<Self, DeserializationError> {
         // read values
-        let num_value_bytes = source.read_u32( pos)?;
-        let values = source.read_u8_vec( pos, num_value_bytes as usize)?;
+        let num_value_bytes = source.read_u32(pos)?;
+        let values = source.read_u8_vec(pos, num_value_bytes as usize)?;
 
         // read paths
-        let num_paths_bytes = source.read_u32( pos)?;
-        let paths = source.read_u8_vec( pos, num_paths_bytes as usize)?;
+        let num_paths_bytes = source.read_u32(pos)?;
+        let paths = source.read_u8_vec(pos, num_paths_bytes as usize)?;
 
         Ok(FriProofLayer { values, paths })
     }

--- a/fri/src/utils.rs
+++ b/fri/src/utils.rs
@@ -61,7 +61,7 @@ pub fn map_positions_to_indexes(
 pub fn hash_values<H: Hasher, E: FieldElement, const N: usize>(
     values: &[[E; N]],
 ) -> Vec<H::Digest> {
-    let mut result: Vec<H::Digest> = uninit_vector(values.len());
+    let mut result: Vec<H::Digest> = unsafe { uninit_vector(values.len()) };
     iter_mut!(result, 1024).zip(values).for_each(|(r, v)| {
         *r = H::hash_elements(v);
     });

--- a/math/src/fft/concurrent.rs
+++ b/math/src/fft/concurrent.rs
@@ -31,7 +31,7 @@ pub fn evaluate_poly_with_offset<B: StarkField, E: FieldElement<BaseField = B>>(
 ) -> Vec<E> {
     let domain_size = p.len() * blowup_factor;
     let g = B::get_root_of_unity(log2(domain_size));
-    let mut result = uninit_vector(domain_size);
+    let mut result = unsafe { uninit_vector(domain_size) };
 
     result
         .as_mut_slice()

--- a/math/src/fft/serial.rs
+++ b/math/src/fft/serial.rs
@@ -34,7 +34,7 @@ pub fn evaluate_poly_with_offset<B: StarkField, E: FieldElement<BaseField = B>>(
 ) -> Vec<E> {
     let domain_size = p.len() * blowup_factor;
     let g = B::get_root_of_unity(log2(domain_size));
-    let mut result = uninit_vector(domain_size);
+    let mut result = unsafe { uninit_vector(domain_size) };
 
     result
         .as_mut_slice()

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -10,7 +10,7 @@ use core::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     slice,
 };
-use utils::{AsBytes, Serializable};
+use utils::{AsBytes, ByteWriter, Serializable};
 
 // QUADRATIC EXTENSION FIELD
 // ================================================================================================
@@ -274,7 +274,7 @@ impl<B: StarkField> AsBytes for QuadExtension<B> {
 // ------------------------------------------------------------------------------------------------
 
 impl<B: StarkField> Serializable for QuadExtension<B> {
-    fn write_into(&self, target: &mut Vec<u8>) {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.0.write_into(target);
         self.1.write_into(target);
     }

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -16,7 +16,7 @@ use core::{
     slice,
 };
 use rand::{distributions::Uniform, prelude::*};
-use utils::{AsBytes, Serializable};
+use utils::{AsBytes, ByteWriter, Serializable};
 
 #[cfg(test)]
 mod tests;
@@ -320,8 +320,8 @@ impl AsBytes for BaseElement {
 // ------------------------------------------------------------------------------------------------
 
 impl Serializable for BaseElement {
-    fn write_into(&self, target: &mut Vec<u8>) {
-        target.extend_from_slice(&self.0.to_le_bytes());
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_u8_slice(&self.0.to_le_bytes());
     }
 }
 

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -16,7 +16,7 @@ use core::{
     slice,
 };
 use rand::{distributions::Uniform, prelude::*};
-use utils::{AsBytes, Serializable};
+use utils::{AsBytes, ByteWriter, Serializable};
 
 #[cfg(test)]
 mod tests;
@@ -394,9 +394,9 @@ impl AsBytes for BaseElement {
 // ------------------------------------------------------------------------------------------------
 
 impl Serializable for BaseElement {
-    fn write_into(&self, target: &mut Vec<u8>) {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
         // convert from Montgomery representation into canonical representation
-        target.extend_from_slice(&self.as_int().to_le_bytes());
+        target.write_u8_slice(&self.as_int().to_le_bytes());
     }
 }
 

--- a/math/src/polynom/mod.rs
+++ b/math/src/polynom/mod.rs
@@ -295,7 +295,7 @@ pub fn degree_of<E: FieldElement>(poly: &[E]) -> usize {
 // HELPER FUNCTIONS
 // ================================================================================================
 fn get_zero_roots<E: FieldElement>(xs: &[E]) -> Vec<E> {
-    let mut result = utils::uninit_vector(xs.len() + 1);
+    let mut result = unsafe { utils::uninit_vector(xs.len() + 1) };
     fill_zero_roots(xs, &mut result);
     result
 }

--- a/math/src/utils/mod.rs
+++ b/math/src/utils/mod.rs
@@ -19,7 +19,7 @@ mod tests;
 /// When `concurrent` feature is enabled, series generation is done concurrently in multiple
 /// threads.
 pub fn get_power_series<E: FieldElement>(b: E, n: usize) -> Vec<E> {
-    let mut result = uninit_vector(n);
+    let mut result = unsafe { uninit_vector(n) };
     batch_iter_mut!(&mut result, 1024, |batch: &mut [E], batch_offset: usize| {
         let start = b.exp((batch_offset as u64).into());
         fill_power_series(batch, b, start);
@@ -31,7 +31,7 @@ pub fn get_power_series<E: FieldElement>(b: E, n: usize) -> Vec<E> {
 /// When `concurrent` feature is enabled, series generation is done concurrently in multiple
 /// threads.
 pub fn get_power_series_with_offset<E: FieldElement>(b: E, s: E, n: usize) -> Vec<E> {
-    let mut result = uninit_vector(n);
+    let mut result = unsafe { uninit_vector(n) };
     batch_iter_mut!(&mut result, 1024, |batch: &mut [E], batch_offset: usize| {
         let start = s * b.exp((batch_offset as u64).into());
         fill_power_series(batch, b, start);
@@ -64,7 +64,7 @@ where
 /// Computes a multiplicative inverse of a sequence of elements using batch inversion method.
 /// Any ZEROs in the provided sequence are ignored.
 pub fn batch_inversion<E: FieldElement>(values: &[E]) -> Vec<E> {
-    let mut result: Vec<E> = uninit_vector(values.len());
+    let mut result: Vec<E> = unsafe { uninit_vector(values.len()) };
     batch_iter_mut!(&mut result, 1024, |batch: &mut [E], batch_offset: usize| {
         let start = batch_offset;
         let end = start + batch.len();
@@ -179,7 +179,7 @@ pub fn read_elements_into_vec<E: FieldElement>(
     }
 
     let num_elements = source.len() / E::ELEMENT_BYTES;
-    let mut result = uninit_vector(num_elements);
+    let mut result = unsafe { uninit_vector(num_elements) };
     read_elements_into(source, &mut result)?;
     Ok(result)
 }

--- a/math/src/utils/tests.rs
+++ b/math/src/utils/tests.rs
@@ -91,7 +91,7 @@ fn log2() {
 
 #[test]
 fn uninit_vector() {
-    let result = super::uninit_vector::<BaseElement>(16);
+    let result = unsafe { super::uninit_vector::<BaseElement>(16) };
     assert_eq!(16, result.len());
     assert_eq!(16, result.capacity());
 }

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -14,7 +14,7 @@ pub use common::{
 };
 pub use crypto;
 pub use math;
-pub use utils::Serializable;
+pub use utils::{ByteWriter, Serializable};
 
 pub mod iterators {
     #[cfg(feature = "concurrent")]

--- a/prover/src/monolith/constraints/commitment.rs
+++ b/prover/src/monolith/constraints/commitment.rs
@@ -84,7 +84,7 @@ impl<E: FieldElement, H: Hasher> ConstraintCommitment<E, H> {
 
 /// Computes hashes of evaluations grouped by row.
 fn hash_evaluations<E: FieldElement, H: Hasher>(evaluations: &[Vec<E>]) -> Vec<H::Digest> {
-    let mut result = uninit_vector::<H::Digest>(evaluations[0].len());
+    let mut result = unsafe { uninit_vector::<H::Digest>(evaluations[0].len()) };
     batch_iter_mut!(
         &mut result,
         128, // min batch size

--- a/prover/src/monolith/constraints/composition_poly.rs
+++ b/prover/src/monolith/constraints/composition_poly.rs
@@ -131,9 +131,11 @@ impl<B: StarkField, E: FieldElement<BaseField = B>> CompositionPoly<B, E> {
 fn transpose<E: FieldElement>(coefficients: Vec<E>, num_columns: usize) -> Vec<Vec<E>> {
     let column_len = coefficients.len() / num_columns;
 
-    let mut result = (0..num_columns)
-        .map(|_| uninit_vector(column_len))
-        .collect::<Vec<_>>();
+    let mut result = unsafe {
+        (0..num_columns)
+            .map(|_| uninit_vector(column_len))
+            .collect::<Vec<_>>()
+    };
 
     // TODO: implement multi-threaded version
     for (i, coeff) in coefficients.into_iter().enumerate() {

--- a/prover/src/monolith/constraints/evaluation_table.rs
+++ b/prover/src/monolith/constraints/evaluation_table.rs
@@ -48,7 +48,7 @@ impl<B: StarkField, E: FieldElement<BaseField = B>> ConstraintEvaluationTable<B,
         let num_columns = divisors.len();
         let num_rows = domain.ce_domain_size();
         ConstraintEvaluationTable {
-            evaluations: (0..num_columns).map(|_| uninit_vector(num_rows)).collect(),
+            evaluations: unsafe { (0..num_columns).map(|_| uninit_vector(num_rows)).collect() },
             divisors,
             domain_offset: domain.offset(),
             trace_length: domain.trace_length(),
@@ -68,13 +68,15 @@ impl<B: StarkField, E: FieldElement<BaseField = B>> ConstraintEvaluationTable<B,
         let num_rows = domain.ce_domain_size();
         let num_t_columns = transition_constraint_degrees.len();
         ConstraintEvaluationTable {
-            evaluations: (0..num_columns).map(|_| uninit_vector(num_rows)).collect(),
+            evaluations: unsafe { (0..num_columns).map(|_| uninit_vector(num_rows)).collect() },
             divisors,
             domain_offset: domain.offset(),
             trace_length: domain.trace_length(),
-            t_evaluations: (0..num_t_columns)
-                .map(|_| uninit_vector(num_rows))
-                .collect(),
+            t_evaluations: unsafe {
+                (0..num_t_columns)
+                    .map(|_| uninit_vector(num_rows))
+                    .collect()
+            },
             t_expected_degrees: transition_constraint_degrees,
         }
     }
@@ -358,7 +360,7 @@ fn get_inv_evaluation<B: StarkField>(
     let g = B::get_root_of_unity(domain_size.trailing_zeros()).exp(a.into());
 
     // compute x^a - b for all x
-    let mut evaluations = uninit_vector(n);
+    let mut evaluations = unsafe { uninit_vector(n) };
     batch_iter_mut!(
         &mut evaluations,
         128, // min batch size

--- a/prover/src/monolith/constraints/periodic_table.rs
+++ b/prover/src/monolith/constraints/periodic_table.rs
@@ -58,7 +58,7 @@ impl<B: StarkField> PeriodicValueTable<B> {
         // table in such a way that values for the same row are adjacent to each other.
         let row_width = polys.len();
         let column_length = max_poly_size * air.ce_blowup_factor();
-        let mut values = uninit_vector(row_width * column_length);
+        let mut values = unsafe { uninit_vector(row_width * column_length) };
         for i in 0..column_length {
             for (j, column) in evaluations.iter().enumerate() {
                 values[i * row_width + j] = column[i % column.len()];

--- a/prover/src/monolith/trace/execution_trace.rs
+++ b/prover/src/monolith/trace/execution_trace.rs
@@ -44,7 +44,7 @@ impl<B: StarkField> ExecutionTrace<B> {
             "execution trace length must be a power of 2"
         );
 
-        let registers = (0..width).map(|_| uninit_vector(length)).collect();
+        let registers = unsafe { (0..width).map(|_| uninit_vector(length)).collect() };
         ExecutionTrace(registers)
     }
 

--- a/prover/src/monolith/trace/trace_table.rs
+++ b/prover/src/monolith/trace/trace_table.rs
@@ -77,7 +77,7 @@ impl<B: StarkField> TraceTable<B> {
     /// Builds a Merkle tree out of trace table rows (hash of each row becomes a leaf in the tree).
     pub fn build_commitment<H: Hasher>(&self) -> MerkleTree<H> {
         // allocate vector to store row hashes
-        let mut hashed_states = uninit_vector::<H::Digest>(self.len());
+        let mut hashed_states = unsafe { uninit_vector::<H::Digest>(self.len()) };
 
         // iterate though table rows, hashing each row; the hashing is done by first copying
         // the state into trace_state buffer to avoid unneeded allocations, and then by applying

--- a/utils/src/errors.rs
+++ b/utils/src/errors.rs
@@ -8,13 +8,14 @@ use core::fmt;
 // DESERIALIZATION ERROR
 // ================================================================================================
 
+/// Defines errors which can occur during deserialization.
 #[derive(Debug, PartialEq)]
 pub enum DeserializationError {
-    /// Value {0} cannot be deserialized as {}
+    /// A value read from the input could not be deserialized into a valid value.
     InvalidValue(String, String),
-    /// Unexpected EOF
+    /// An end of input was reached before a valid value could be deserialized.
     UnexpectedEOF,
-    /// Unknown error: {0}
+    /// An unknown error has occurred.
     UnknownError(String),
 }
 

--- a/utils/src/iterators.rs
+++ b/utils/src/iterators.rs
@@ -3,10 +3,14 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+/// Returns either a regular or a parallel iterator depending on whether `concurrent` feature
+/// is enabled.
+///
 /// When `concurrent` feature is enabled, creates a parallel iterator; otherwise, creates a
 /// regular iterator. Optionally, `min_length` can be used to specify the minimum length of
 /// iterator to be processed in each thread.
-/// Adapted from: https://github.com/arkworks-rs/utils/blob/master/src/lib.rs
+///
+/// Adapted from: <https://github.com/arkworks-rs/utils/blob/master/src/lib.rs>
 #[macro_export]
 macro_rules! iter {
     ($e: expr) => {{
@@ -29,10 +33,14 @@ macro_rules! iter {
     }};
 }
 
+/// Returns either a regular or a parallel mutable iterator depending on whether `concurrent`
+/// feature is enabled.
+///
 /// When `concurrent` feature is enabled, creates a mutable parallel iterator; otherwise,
-/// creates a regular iterator. Optionally, `min_length` can be used to specify the minimum
-/// length of iterator to be processed in each thread.
-/// Adapted from: https://github.com/arkworks-rs/utils/blob/master/src/lib.rs
+/// creates a regular mutable iterator. Optionally, `min_length` can be used to specify the
+/// minimum length of iterator to be processed in each thread.
+///
+/// Adapted from: <https://github.com/arkworks-rs/utils/blob/master/src/lib.rs>
 #[macro_export]
 macro_rules! iter_mut {
     ($e: expr) => {{
@@ -55,6 +63,9 @@ macro_rules! iter_mut {
     }};
 }
 
+/// Applies a procedure to the provided slice either in a single thread or multiple threads
+/// based on whether `concurrent` feature is enabled.
+///
 /// When `concurrent` feature is enabled, breaks the slice into batches and processes each
 /// batch in a separate thread; otherwise, the entire slice is processed as a single batch
 /// in one thread. Optionally, `min_batch_size` can be used to specify the minimum size of

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -3,8 +3,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-//! This crate contains utility traits, functions, and macros used by Winterfell STARK prover
-//! and verifier.
+//! This crate contains utility traits, functions, and macros used by other crates of Winterfell
+//! STARK prover and verifier.
 
 use core::{convert::TryInto, mem, slice};
 
@@ -22,37 +22,49 @@ use rayon::prelude::*;
 // SERIALIZABLE
 // ================================================================================================
 
+/// Defines how to serialize `Self` into bytes.
 pub trait Serializable: Sized {
     // REQUIRED METHODS
     // --------------------------------------------------------------------------------------------
-    /// Should serialize self into bytes, and append the bytes at the end of the `target` vector.
+    /// Serializes `self` into bytes and appends the bytes at the end of the `target` vector.
     fn write_into(&self, target: &mut Vec<u8>);
 
     // PROVIDED METHODS
     // --------------------------------------------------------------------------------------------
 
-    /// Serializes self into a vector of bytes.
+    /// Serializes `self` into a vector of bytes.
     fn to_bytes(&self) -> Vec<u8> {
-        let mut result = Vec::new(); // TODO: use size hint to initialize with capacity
+        let mut result = Vec::with_capacity(self.get_size_hint());
         self.write_into(&mut result);
         result
     }
 
-    /// Serializes all elements of the `source`, and appends the resulting bytes at the end of
-    /// the `target` vector. This method does not write any metadata (e.g. number of serialized
-    /// elements) into the `target`.
+    /// Serializes all elements of the `source` and appends the resulting bytes at the end of
+    /// the `target` vector.
+    ///
+    /// This method does not write any metadata (e.g. number of serialized elements) into the
+    /// `target`.
     fn write_batch_into(source: &[Self], target: &mut Vec<u8>) {
         for item in source {
             item.write_into(target);
         }
     }
 
-    /// Serializes all individual elements contained in the `source`, and appends the resulting
-    /// bytes at the end of the `target` vector. This method does not write any metadata (e.g.
-    /// number of serialized elements) into the `target`.
+    /// Serializes all individual elements contained in the `source` and appends the resulting
+    /// bytes at the end of the `target` vector.
+    ///
+    /// This method does not write any metadata (e.g. number of serialized elements) into the
+    /// `target`.
     fn write_array_batch_into<const N: usize>(source: &[[Self; N]], target: &mut Vec<u8>) {
         let source = flatten_slice_elements(source);
         Self::write_batch_into(source, target);
+    }
+
+    /// Returns an estimate of how many bytes are needed to represent self.
+    ///
+    /// The default implementation returns zero.
+    fn get_size_hint(&self) -> usize {
+        0
     }
 }
 
@@ -60,79 +72,99 @@ impl Serializable for () {
     fn write_into(&self, _target: &mut Vec<u8>) {}
 }
 
-
 // BYTE READER
 // ================================================================================================
 
+/// Defines how primitive values are to be read from `Self`.
 pub trait ByteReader {
-
-    /// Reads a byte from the specified source at the specified position, and increments `pos`
-    /// by one.
-    /// Returns an error if `pos` is out of bounds.
+    /// Returns a single byte read from `self` at the specified position.
+    ///
+    /// After the byte is read, `pos` is incremented by one.
+    ///
+    /// # Errors
+    /// Returns a `DeserializationError` error if `pos` is out of bounds.
     fn read_u8(&self, pos: &mut usize) -> Result<u8, DeserializationError>;
 
+    /// Returns a u16 value read from `self` in little-endian byte order starting at the specified
+    /// position.
+    ///
+    /// After the value is read, `pos` is incremented by two.
+    ///
+    /// # Errors
+    /// Returns an error if a u16 value could not be read.
     fn read_u16(&self, pos: &mut usize) -> Result<u16, DeserializationError>;
 
+    /// Returns a u32 value read from `self` in little-endian byte order starting at the specified
+    /// position.
+    ///
+    /// After the value is read, `pos` is incremented by four.
+    ///
+    /// # Errors
+    /// Returns an error if a u32 value could not be read.
     fn read_u32(&self, pos: &mut usize) -> Result<u32, DeserializationError>;
 
+    /// Returns a u64 value read from `self` in little-endian byte order starting at the specified
+    /// position.
+    ///
+    /// After the value is read, `pos` is incremented by eight.
+    ///
+    /// # Errors
+    /// Returns an error if a u64 value could not be read.
     fn read_u64(&self, pos: &mut usize) -> Result<u64, DeserializationError>;
 
+    /// Returns a byte vector of the specified length read from `self` starting at the specified
+    /// position.
+    ///
+    /// After the vector is read, `pos` is incremented by the length of the vector.
+    ///
+    /// # Errors
+    /// Returns an error if a u16 value could not be read.
     fn read_u8_vec(&self, pos: &mut usize, len: usize) -> Result<Vec<u8>, DeserializationError>;
 }
 
 impl ByteReader for [u8] {
-
     fn read_u8(&self, pos: &mut usize) -> Result<u8, DeserializationError> {
         if *pos >= self.len() {
             return Err(DeserializationError::UnexpectedEOF);
         }
         let result = self[*pos];
-    
+
         *pos += 1;
         Ok(result)
     }
 
-    /// Reads a u16 value from the specified source starting at the specified position, and
-    /// increments `pos` by two. The u16 value is assumed to be in little-endian byte order.
-    /// Returns an error if a u16 value could not be read from the specified source.
     fn read_u16(&self, pos: &mut usize) -> Result<u16, DeserializationError> {
         let end_pos = *pos + 2;
         if end_pos > self.len() {
             return Err(DeserializationError::UnexpectedEOF);
         }
-    
+
         let result = u16::from_le_bytes(
             self[*pos..end_pos]
                 .try_into()
                 .map_err(|err| DeserializationError::UnknownError(format!("{}", err)))?,
         );
-    
+
         *pos = end_pos;
         Ok(result)
     }
 
-    /// Reads a u32 value from the specified source starting at the specified position, and
-    /// increments `pos` by four. The u32 value is assumed to be in little-endian byte order.
-    /// Returns an error if a u32 value could not be read from the specified source.
     fn read_u32(&self, pos: &mut usize) -> Result<u32, DeserializationError> {
         let end_pos = *pos + 4;
         if end_pos > self.len() {
             return Err(DeserializationError::UnexpectedEOF);
         }
-    
+
         let result = u32::from_le_bytes(
             self[*pos..end_pos]
                 .try_into()
                 .map_err(|err| DeserializationError::UnknownError(format!("{}", err)))?,
         );
-    
+
         *pos = end_pos;
         Ok(result)
     }
 
-    /// Reads a u64 value from the specified source starting at the specified position, and
-    /// increments `pos` by eight. The u64 value is assumed to be in little-endian byte order.
-    /// Returns an error if a u64 value could not be read from the specified source.
     fn read_u64(&self, pos: &mut usize) -> Result<u64, DeserializationError> {
         let end_pos = *pos + 8;
         if end_pos > self.len() {
@@ -149,9 +181,6 @@ impl ByteReader for [u8] {
         Ok(result)
     }
 
-    /// Reads a byte vector of specified from the specified source starting at the specified
-    /// position, and increments `pos` by the length of the vector.
-    /// Returns an error if a vector of the specified length could not be read from the source.
     fn read_u8_vec(&self, pos: &mut usize, len: usize) -> Result<Vec<u8>, DeserializationError> {
         let end_pos = *pos + len as usize;
         if end_pos > self.len() {
@@ -160,13 +189,64 @@ impl ByteReader for [u8] {
         let result = self[*pos..end_pos].to_vec();
         *pos = end_pos;
         Ok(result)
-        
+    }
+}
+
+impl ByteReader for Vec<u8> {
+    fn read_u8(&self, pos: &mut usize) -> Result<u8, DeserializationError> {
+        self.as_slice().read_u8(pos)
+    }
+
+    fn read_u16(&self, pos: &mut usize) -> Result<u16, DeserializationError> {
+        self.as_slice().read_u16(pos)
+    }
+
+    fn read_u32(&self, pos: &mut usize) -> Result<u32, DeserializationError> {
+        self.as_slice().read_u32(pos)
+    }
+
+    fn read_u64(&self, pos: &mut usize) -> Result<u64, DeserializationError> {
+        self.as_slice().read_u64(pos)
+    }
+
+    fn read_u8_vec(&self, pos: &mut usize, len: usize) -> Result<Vec<u8>, DeserializationError> {
+        self.as_slice().read_u8_vec(pos, len)
+    }
+}
+
+// BYTE WRITER
+// ================================================================================================
+
+/// Defines how primitive values are to be written into `Self`.
+pub trait ByteWriter {
+    fn write_u8(&mut self, value: u8);
+    fn write_u16(&mut self, value: u16);
+    fn write_u32(&mut self, value: u32);
+    fn write_u8_slice(&mut self, values: &[u8]);
+}
+
+impl ByteWriter for Vec<u8> {
+    fn write_u8(&mut self, value: u8) {
+        self.push(value);
+    }
+
+    fn write_u16(&mut self, value: u16) {
+        self.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn write_u32(&mut self, value: u32) {
+        self.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn write_u8_slice(&mut self, values: &[u8]) {
+        self.extend_from_slice(values);
     }
 }
 
 // AS BYTES
 // ================================================================================================
 
+/// Defines a zero-copy representation of `Self` as a sequence of bytes.
 pub trait AsBytes {
     fn as_bytes(&self) -> &[u8];
 }
@@ -192,9 +272,11 @@ impl<const N: usize> AsBytes for [[u8; N]] {
 // VECTOR FUNCTIONS
 // ================================================================================================
 
-/// Returns a vector of the specified length with un-initialized memory. This is faster than
-/// requesting a vector with initialized memory and is useful when we overwrite all contents of
-/// the vector immediately after initialization. Otherwise, this will lead to undefined behavior.
+/// Returns a vector of the specified length with un-initialized memory.
+///
+/// This is faster than requesting a vector with initialized memory and is useful when we
+/// overwrite all contents of the vector immediately after initialization. Otherwise, this will
+/// lead to undefined behavior.
 pub fn uninit_vector<T>(length: usize) -> Vec<T> {
     let mut vector = Vec::with_capacity(length);
     unsafe {
@@ -208,6 +290,7 @@ pub fn uninit_vector<T>(length: usize) -> Vec<T> {
 
 /// Transmutes a vector of n elements into a vector of n / N elements, each of which is
 /// an array of N elements.
+///
 /// Panics if n is not divisible by N.
 pub fn group_vector_elements<T, const N: usize>(source: Vec<T>) -> Vec<[T; N]> {
     assert_eq!(
@@ -225,6 +308,7 @@ pub fn group_vector_elements<T, const N: usize>(source: Vec<T>) -> Vec<[T; N]> {
 
 /// Transmutes a slice of n elements into a slice of n / N elements, each of which is
 /// an array of N elements.
+///
 /// Panics if n is not divisible by N.
 pub fn group_slice_elements<T, const N: usize>(source: &[T]) -> &[[T; N]] {
     assert_eq!(

--- a/utils/src/tests.rs
+++ b/utils/src/tests.rs
@@ -3,6 +3,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use super::ByteReader;
+
+// VECTOR UTILS TESTS
+// ================================================================================================
+
 #[test]
 fn group_vector_elements() {
     let n = 16;
@@ -22,6 +27,9 @@ fn group_vector_elements() {
         }
     }
 }
+
+// SLICE UTILS TESTS
+// ================================================================================================
 
 #[test]
 fn flatten_slice_elements() {
@@ -48,15 +56,15 @@ fn read_u8() {
     let a = [1u8, 3, 5, 7];
 
     let mut pos = 0;
-    assert_eq!(1, super::read_u8(&a, &mut pos).unwrap());
+    assert_eq!(1, a.read_u8(&mut pos).unwrap());
     assert_eq!(1, pos);
 
     pos += 1;
-    assert_eq!(5, super::read_u8(&a, &mut pos).unwrap());
+    assert_eq!(5, a.read_u8(&mut pos).unwrap());
     assert_eq!(3, pos);
 
     pos = 4;
-    assert!(super::read_u8(&a, &mut pos).is_err());
+    assert!(a.read_u8(&mut pos).is_err());
 }
 
 #[test]
@@ -65,14 +73,14 @@ fn read_u16() {
     a.append(&mut 23456u16.to_le_bytes().to_vec());
 
     let mut pos = 0;
-    assert_eq!(12345, super::read_u16(&a, &mut pos).unwrap());
+    assert_eq!(12345, a.read_u16(&mut pos).unwrap());
     assert_eq!(2, pos);
 
-    assert_eq!(23456, super::read_u16(&a, &mut pos).unwrap());
+    assert_eq!(23456, a.read_u16(&mut pos).unwrap());
     assert_eq!(4, pos);
 
     pos = 3;
-    assert!(super::read_u16(&a, &mut pos).is_err());
+    assert!(a.read_u16(&mut pos).is_err());
 }
 
 #[test]
@@ -81,14 +89,14 @@ fn read_u32() {
     a.append(&mut 2345678910u32.to_le_bytes().to_vec());
 
     let mut pos = 0;
-    assert_eq!(123456789, super::read_u32(&a, &mut pos).unwrap());
+    assert_eq!(123456789, a.read_u32(&mut pos).unwrap());
     assert_eq!(4, pos);
 
-    assert_eq!(2345678910, super::read_u32(&a, &mut pos).unwrap());
+    assert_eq!(2345678910, a.read_u32(&mut pos).unwrap());
     assert_eq!(8, pos);
 
     pos = 6;
-    assert!(super::read_u32(&a, &mut pos).is_err());
+    assert!(a.read_u32(&mut pos).is_err());
 }
 
 #[test]
@@ -97,14 +105,14 @@ fn read_u64() {
     a.append(&mut 234567891011u64.to_le_bytes().to_vec());
 
     let mut pos = 0;
-    assert_eq!(12345678910, super::read_u64(&a, &mut pos).unwrap());
+    assert_eq!(12345678910, a.read_u64(&mut pos).unwrap());
     assert_eq!(8, pos);
 
-    assert_eq!(234567891011, super::read_u64(&a, &mut pos).unwrap());
+    assert_eq!(234567891011, a.read_u64(&mut pos).unwrap());
     assert_eq!(16, pos);
 
     pos = 14;
-    assert!(super::read_u64(&a, &mut pos).is_err());
+    assert!(a.read_u64(&mut pos).is_err());
 }
 
 #[test]
@@ -112,17 +120,17 @@ fn read_u8_vec() {
     let a = [1u8, 2, 3, 4, 5, 6, 7, 8];
 
     let mut pos = 0;
-    assert_eq!(vec![1, 2], super::read_u8_vec(&a, &mut pos, 2).unwrap());
+    assert_eq!(vec![1, 2], a.read_u8_vec(&mut pos, 2).unwrap());
     assert_eq!(2, pos);
 
-    assert_eq!(vec![3, 4, 5], super::read_u8_vec(&a, &mut pos, 3).unwrap());
+    assert_eq!(vec![3, 4, 5], a.read_u8_vec(&mut pos, 3).unwrap());
     assert_eq!(5, pos);
 
-    assert_eq!(vec![6, 7], super::read_u8_vec(&a, &mut pos, 2).unwrap());
+    assert_eq!(vec![6, 7], a.read_u8_vec(&mut pos, 2).unwrap());
     assert_eq!(7, pos);
 
-    assert_eq!(vec![8], super::read_u8_vec(&a, &mut pos, 1).unwrap());
+    assert_eq!(vec![8], a.read_u8_vec(&mut pos, 1).unwrap());
 
     pos = 7;
-    assert!(super::read_u8_vec(&a, &mut pos, 2).is_err());
+    assert!(a.read_u8_vec(&mut pos, 2).is_err());
 }

--- a/utils/src/tests.rs
+++ b/utils/src/tests.rs
@@ -28,26 +28,6 @@ fn group_vector_elements() {
     }
 }
 
-// SLICE UTILS TESTS
-// ================================================================================================
-
-#[test]
-fn flatten_slice_elements() {
-    let a = vec![[1, 2, 3, 4], [5, 6, 7, 8]];
-
-    let b = super::flatten_slice_elements(&a);
-    assert_eq!([1, 2, 3, 4, 5, 6, 7, 8], b);
-}
-
-#[test]
-fn transpose_slice() {
-    let n = 8;
-    let a = (0..n).map(|v| v as u64).collect::<Vec<_>>();
-    let b: Vec<[u64; 2]> = super::transpose_slice(&a);
-
-    assert_eq!([[0, 4], [1, 5], [2, 6], [3, 7]].to_vec(), b);
-}
-
 // DESERIALIZATION TESTS
 // ================================================================================================
 

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -6,7 +6,7 @@
 pub use common::{
     errors::VerifierError, proof::StarkProof, Air, FieldExtension, HashFunction, TraceInfo,
 };
-pub use utils::Serializable;
+pub use utils::{ByteWriter, Serializable};
 
 pub use crypto;
 use crypto::{


### PR DESCRIPTION
This PR refactors `utils` crate and adds Rust-style documentation to it in preparation for publishing the crate to crates.io.

The refactoring includes:
- [x] Grouped deserializers into a trait: `ByteReader`
- [x] Added a trait for serialization: `ByteWriter`
- [x] Marked `uninit_vector()` function as unsafe