### PR TITLE
Fix wrong positive of E0391 (cycle error) for FieldElement trait in toolchains < 1.52.0

### DIFF
--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -44,7 +44,7 @@ pub trait FieldElement:
     + MulAssign<Self>
     + DivAssign<Self>
     + Neg<Output = Self>
-    + From<Self::BaseField>
+    + From<<Self as FieldElement>::BaseField>
     + From<u128>
     + From<u64>
     + From<u32>


### PR DESCRIPTION
I did not see any mention of MSRV, and the project fails to compile in stable 1.51.0 with the following error

> error[E0391]: cycle detected when computing the supertraits of `field::traits::FieldElement`
   --> math/src/field/traits.rs:27:1
    |
27  | / pub trait FieldElement:
28  | |     Copy
29  | |     + Clone
30  | |     + Debug
...   |
185 | |     fn prng_vector(seed: [u8; 32], n: usize) -> Vec<Self>;
186 | | }
    | |_^
    |
    = note: ...which again requires computing the supertraits of `field::traits::FieldElement`, completing the cycle
note: cycle used when collecting item types in module `field::traits`
   --> math/src/field/traits.rs:27:1
    |
27  | / pub trait FieldElement:
28  | |     Copy
29  | |     + Clone
30  | |     + Debug
...   |
185 | |     fn prng_vector(seed: [u8; 32], n: usize) -> Vec<Self>;
186 | | }
    | |_^
error: aborting due to previous error

The oneline change allows to compile with lower versions