### PR TITLE
Dependency updates

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -28,7 +28,7 @@ concurrent = ["rayon"]
 [dependencies]
 utils = { path = "../utils", package = "winter-utils" }
 math = { path = "../math", package = "winter-math" }
-blake3 = "0.3"
+blake3 = "1.0"
 sha3 = "0.9"
 rayon = { version = "1.5", optional = true }
 

--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -68,7 +68,7 @@ impl<B: StarkField> Hasher for Blake3_256<B> {
     type Digest = Digest256;
 
     fn hash(bytes: &[u8]) -> Self::Digest {
-        Digest256(blake3::hash(bytes).into())
+        Digest256(*blake3::hash(bytes).as_bytes())
     }
 
     fn merge(values: &[Self::Digest; 2]) -> Self::Digest {
@@ -79,7 +79,7 @@ impl<B: StarkField> Hasher for Blake3_256<B> {
         let mut data = [0; 40];
         data[..32].copy_from_slice(&seed.0);
         data[32..].copy_from_slice(&value.to_le_bytes());
-        Digest256(blake3::hash(&data).into())
+        Digest256(*blake3::hash(&data).as_bytes())
     }
 }
 
@@ -88,7 +88,7 @@ impl<B: StarkField> ElementHasher for Blake3_256<B> {
 
     fn hash_elements<E: FieldElement<BaseField = Self::BaseField>>(elements: &[E]) -> Self::Digest {
         let bytes = E::elements_as_bytes(elements);
-        Digest256(blake3::hash(bytes).into())
+        Digest256(*blake3::hash(bytes).as_bytes())
     }
 }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -25,8 +25,8 @@ prover = { path = "../prover" }
 verifier = { path = "../verifier" }
 hex = "0.4"
 log = "0.4"
-blake3 = "0.3"
-env_logger = "0.8"
+blake3 = "1.0"
+env_logger = "0.9"
 structopt = "0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR brings the following dependencies up to date:

- `blake3` to 1.0
- `env_logger` to 0.9