### PR TITLE
Malleable field elements

### DIFF
--- a/air/src/proof/queries.rs
+++ b/air/src/proof/queries.rs
@@ -67,7 +67,7 @@ impl Queries {
                 elements_per_query,
                 "all queries must contain the same number of evaluations"
             );
-            values.extend_from_slice(E::elements_as_bytes(elements));
+            values.write(elements);
         }
 
         // serialize internal nodes of the batch Merkle proof; we care about internal nodes only

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -46,6 +46,7 @@ impl<B: StarkField> FieldElement for QuadExtensionA<B> {
     type BaseField = B;
 
     const ELEMENT_BYTES: usize = B::ELEMENT_BYTES * 2;
+    const IS_MALLEABLE: bool = B::IS_MALLEABLE;
     const ZERO: Self = Self(B::ZERO, B::ZERO);
     const ONE: Self = Self(B::ONE, B::ZERO);
 
@@ -119,6 +120,11 @@ impl<B: StarkField> FieldElement for QuadExtensionA<B> {
         // get twice the number of base elements, and re-interpret them as quad field elements
         let result = B::prng_vector(seed, n * 2);
         Self::base_to_quad_vector(result)
+    }
+
+    fn normalize(&mut self) {
+        self.0.normalize();
+        self.1.normalize();
     }
 }
 

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -69,6 +69,8 @@ impl FieldElement for BaseElement {
 
     const ELEMENT_BYTES: usize = ELEMENT_BYTES;
 
+    const IS_MALLEABLE: bool = false;
+
     fn inv(self) -> Self {
         BaseElement(inv(self.0))
     }
@@ -142,6 +144,10 @@ impl FieldElement for BaseElement {
         let range = Uniform::from(RANGE);
         let g = StdRng::from_seed(seed);
         g.sample_iter(range).take(n).map(BaseElement).collect()
+    }
+
+    fn normalize(&mut self) {
+        // do nothing since the internal and canonical representations are the same
     }
 }
 

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -79,6 +79,7 @@ impl FieldElement for BaseElement {
     const ONE: Self = BaseElement::new(1);
 
     const ELEMENT_BYTES: usize = ELEMENT_BYTES;
+    const IS_MALLEABLE: bool = true;
 
     fn exp(self, power: Self::PositiveInteger) -> Self {
         let mut b = self;
@@ -172,6 +173,11 @@ impl FieldElement for BaseElement {
         let range = Uniform::from(RANGE);
         let g = StdRng::from_seed(seed);
         g.sample_iter(range).take(n).map(BaseElement::new).collect()
+    }
+
+    #[inline(always)]
+    fn normalize(&mut self) {
+        self.0 = normalize(self.0)
     }
 }
 

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -75,6 +75,10 @@ pub trait FieldElement:
     /// Number of bytes needed to encode an element
     const ELEMENT_BYTES: usize;
 
+    /// True if internal representation of an element can be redundant - i.e., multiple
+    /// internal representations map to the same canonical representation.
+    const IS_MALLEABLE: bool;
+
     /// The additive identity.
     const ZERO: Self;
 
@@ -183,6 +187,15 @@ pub trait FieldElement:
     /// Returns a vector of `n` pseudo-random elements drawn uniformly from the entire
     /// field based on the provided `seed`.
     fn prng_vector(seed: [u8; 32], n: usize) -> Vec<Self>;
+
+    // UTILITIES
+    // --------------------------------------------------------------------------------------------
+
+    /// Normalizes internal representation of this element.
+    ///
+    /// Normalization is applicable only to malleable field elements; for non-malleable elements
+    /// this is a no-op.
+    fn normalize(&mut self);
 }
 
 // STARK FIELD


### PR DESCRIPTION
This PR introduces a concept of malleable field elements - i.e., elements which might have redundant internal representation for the same canonical representation. For example, this is the case for field elements where internally elements are stored in the range `[0, 2M)` (rather than `[0, M)`) which we use for our `f62` field (the `f128` field does not have this issue because we don't use Montgomery arithmetic for it).

This also allows us to hash elements consistently by first normalizing their internal representation, and only then hashing them. We do this for malleable elements only, since non-malleable elements don't need to be normalized, and thus, we can hash them directly.

We also make sure that we always write elements into the proof in canonical representation. This avoids issues when trying to deserialize elements where canonical and internal representations differ.

The above fixes should resolve the problems mentioned in https://github.com/novifinancial/winterfell/issues/13#issuecomment-888018333.