### PR TITLE
Hash function with small output

### DIFF
--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -20,11 +20,20 @@ use utils::{
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum HashFunction {
+    /// BLAKE3 hash function with 192 bit output.
+    ///
+    /// When this function is used in the STARK protocol, proof security cannot exceed 96 bits.
+    Blake3_192 = 1,
+
     /// BLAKE3 hash function with 256 bit output.
-    Blake3_256 = 1,
+    ///
+    /// When this function is used in the STARK protocol, proof security cannot exceed 128 bits.
+    Blake3_256 = 2,
 
     /// SHA3 hash function with 256 bit output.
-    Sha3_256 = 2,
+    ///
+    /// When this function is used in the STARK protocol, proof security cannot exceed 128 bits.
+    Sha3_256 = 3,
 }
 
 /// Defines an extension field for the composition polynomial.
@@ -278,6 +287,7 @@ impl HashFunction {
     /// Returns collision resistance of this hash function in bits.
     pub fn collision_resistance(&self) -> u32 {
         match self {
+            Self::Blake3_192 => 96,
             Self::Blake3_256 => 128,
             Self::Sha3_256 => 128,
         }
@@ -295,8 +305,9 @@ impl Deserializable for HashFunction {
     /// Reads a hash function enum from the specified `source`.
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         match source.read_u8()? {
-            1 => Ok(HashFunction::Blake3_256),
-            2 => Ok(HashFunction::Sha3_256),
+            1 => Ok(HashFunction::Blake3_192),
+            2 => Ok(HashFunction::Blake3_256),
+            3 => Ok(HashFunction::Sha3_256),
             value => Err(DeserializationError::InvalidValue(format!(
                 "value {} cannot be deserialized as HashFunction enum",
                 value.to_string()

--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -173,5 +173,8 @@ fn get_conjectured_security(
         query_security += options.grinding_factor();
     }
 
-    cmp::min(cmp::min(field_security, hash_fn_security), query_security) - 1
+    cmp::min(
+        cmp::min(field_security, query_security) - 1,
+        hash_fn_security,
+    )
 }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -31,6 +31,7 @@ pub use hash::{ElementHasher, Hasher};
 pub mod hashers {
     //! Contains implementations of currently supported hash functions.
 
+    pub use super::hash::Blake3_192;
     pub use super::hash::Blake3_256;
     pub use super::hash::Sha3_256;
 }

--- a/crypto/src/merkle/tests.rs
+++ b/crypto/src/merkle/tests.rs
@@ -3,12 +3,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use crate::hash::Digest256;
-
 use super::*;
 use math::fields::f128::BaseElement;
 use proptest::prelude::*;
 
+type Digest256 = crate::hash::ByteDigest<32>;
 type Blake3_256 = crate::hash::Blake3_256<BaseElement>;
 
 static LEAVES4: [[u8; 32]; 4] = [

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -35,6 +35,10 @@ pub struct ExampleOptions {
     #[structopt(subcommand)]
     pub example: ExampleType,
 
+    /// Hash function used in the protocol
+    #[structopt(short = "h", long = "hash_fn", default_value = "blake3_256")]
+    hash_fn: String,
+
     /// Number of queries to include in a proof
     #[structopt(short = "q", long = "queries")]
     num_queries: Option<usize>,
@@ -65,12 +69,18 @@ impl ExampleOptions {
         } else {
             FieldExtension::None
         };
+        let hash_fn = match self.hash_fn.as_str() {
+            "blake3_192" => HashFunction::Blake3_192,
+            "blake3_256" => HashFunction::Blake3_256,
+            "sha3_256" => HashFunction::Sha3_256,
+            val => panic!("'{}' is not a valid hash function option", val),
+        };
 
         ProofOptions::new(
             num_queries,
             blowup_factor,
             self.grinding_factor,
-            HashFunction::Blake3_256,
+            hash_fn,
             field_extension,
             self.folding_factor,
             256,

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -62,7 +62,7 @@ use math::{fft::infer_degree, FieldElement, StarkField};
 
 pub use crypto;
 use crypto::{
-    hashers::{Blake3_256, Sha3_256},
+    hashers::{Blake3_192, Blake3_256, Sha3_256},
     ElementHasher,
 };
 
@@ -141,14 +141,19 @@ pub fn prove<AIR: Air>(
             HashFunction::Blake3_256 => generate_proof::
                 <AIR, AIR::BaseElement, Blake3_256<AIR::BaseElement>>
                 (air, trace, pub_inputs_bytes),
+            HashFunction::Blake3_192 => generate_proof::
+                <AIR, AIR::BaseElement, Blake3_192<AIR::BaseElement>>
+                (air, trace, pub_inputs_bytes),
             HashFunction::Sha3_256 => generate_proof::
                 <AIR, AIR::BaseElement, Sha3_256<AIR::BaseElement>>
                 (air, trace, pub_inputs_bytes)
-            
         },
         FieldExtension::Quadratic => match air.options().hash_fn() {
             HashFunction::Blake3_256 => generate_proof::
                 <AIR, <AIR::BaseElement as StarkField>::QuadExtension, Blake3_256<AIR::BaseElement>>
+                (air, trace, pub_inputs_bytes),
+            HashFunction::Blake3_192 => generate_proof::
+                <AIR, <AIR::BaseElement as StarkField>::QuadExtension, Blake3_192<AIR::BaseElement>>
                 (air, trace, pub_inputs_bytes),
             HashFunction::Sha3_256 => generate_proof::
                 <AIR, <AIR::BaseElement as StarkField>::QuadExtension, Sha3_256<AIR::BaseElement>>

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -51,7 +51,7 @@ pub use utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Se
 
 pub use crypto;
 use crypto::{
-    hashers::{Blake3_256, Sha3_256},
+    hashers::{Blake3_192, Blake3_256, Sha3_256},
     ElementHasher, RandomCoin,
 };
 
@@ -108,6 +108,13 @@ pub fn verify<AIR: Air>(
                     <AIR, AIR::BaseElement, Blake3_256<AIR::BaseElement>>
                     (air, channel, public_coin)
             }
+            HashFunction::Blake3_192 => {
+                let public_coin = RandomCoin::new(&public_coin_seed);
+                let channel = VerifierChannel::new(&air, proof)?;
+                perform_verification::
+                    <AIR, AIR::BaseElement, Blake3_192<AIR::BaseElement>>
+                    (air, channel, public_coin)
+            }
             HashFunction::Sha3_256 => {
                 let public_coin = RandomCoin::new(&public_coin_seed);
                 let channel = VerifierChannel::new(&air, proof)?;
@@ -122,6 +129,13 @@ pub fn verify<AIR: Air>(
                 let channel = VerifierChannel::new(&air, proof)?;
                 perform_verification::
                     <AIR, <AIR::BaseElement as StarkField>::QuadExtension, Blake3_256<AIR::BaseElement>>
+                    (air, channel, public_coin)
+            }
+            HashFunction::Blake3_192 => {
+                let public_coin = RandomCoin::new(&public_coin_seed);
+                let channel = VerifierChannel::new(&air, proof)?;
+                perform_verification::
+                    <AIR, <AIR::BaseElement as StarkField>::QuadExtension, Blake3_192<AIR::BaseElement>>
                     (air, channel, public_coin)
             }
             HashFunction::Sha3_256 => {


### PR DESCRIPTION
This PR addresses #35. The changes include:

- [x] Implement BLAKE3_192 hash function (this basically is a regular BLAKE3 but with truncated output).
- [x] Integrate new hash function choice into prover and verifier.
- [x] Add hash function option to example parameters.
- [ ] Updated benchmarks