### PR TITLE
Rescue prime

### DIFF
--- a/air/src/proof/commitments.rs
+++ b/air/src/proof/commitments.rs
@@ -33,11 +33,9 @@ impl Commitments {
         fri_roots: Vec<H::Digest>,
     ) -> Self {
         let mut bytes = Vec::new();
-        bytes.extend_from_slice(trace_root.as_ref());
-        bytes.extend_from_slice(constraint_root.as_ref());
-        for fri_root in fri_roots.iter() {
-            bytes.extend_from_slice(fri_root.as_ref());
-        }
+        bytes.write(trace_root);
+        bytes.write(constraint_root);
+        bytes.write(fri_roots);
         Commitments(bytes)
     }
 
@@ -46,7 +44,7 @@ impl Commitments {
 
     /// Adds the specified commitment to the list of commitments.
     pub fn add<H: Hasher>(&mut self, commitment: &H::Digest) {
-        self.0.extend_from_slice(commitment.as_ref())
+        commitment.write_into(&mut self.0);
     }
 
     // PARSING

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -5,13 +5,13 @@ This crate contains modules with cryptographic operations needed in STARK proof 
 [Hash](src/hash) module defines a set of hash functions available for cryptographic operations. Currently, the following hash functions are supported:
  
 * SHA3 with 256-bit output.
-* BLAKE3 with either 256-bit or 192-bit output. The smaller output version can be used to reduce STARK proof size, however, it also reduces proof security level to 96 bits.
-* Rescue Prime over a 62-bit field with 248-bit output. Rescue is an arithmetization-friendly hash function which can be used as a building block in recursive proof composition. However, using this function is not yet supported by the Winterfell STARK prover and verifier.
+* BLAKE3 with either 256-bit or 192-bit output. The smaller output version can be used to reduce STARK proof size, however, it also limits proof security level to at most 96 bits.
+* Rescue Prime over a 62-bit field with 248-bit output. Rescue is an arithmetization-friendly hash function and can be used in the STARK protocol when recursive proof composition is desired. However, using this function is not yet supported by the Winterfell STARK prover and verifier.
 
 ### Rescue hash function implementation
 Rescue hash function is implemented according to the Rescue Prime [specifications](https://eprint.iacr.org/2020/1143.pdf) with the following exception:
-* We set the number of rounds to 7, which implies a 40% security margin instead of the 50% margin used in the specifications (a 50% margin rounds up to 8 rounds).
-* When hashing a sequence of elements, we do not append Fp(1) followed by Fp(0) elements to the end of the sequence as padding. Instead, we initialize one of the capacity elements to the number of elements to be hashed, and pad the sequence with Fp(0) elements only.
+* We set the number of rounds to 7, which implies a 40% security margin instead of the 50% margin used in the specifications (a 50% margin rounds up to 8 rounds). The primary motivation for this is that having the number of rounds be one less than a power of two simplifies AIR design for computations involving the hash function.
+* When hashing a sequence of elements, we do not append Fp(1) followed by Fp(0) elements to the end of the sequence as padding. Instead, we initialize one of the capacity elements to the number of elements to be hashed, and pad the sequence with Fp(0) elements only. This ensures that output of the hash function is the same when we hash 8 field elements to compute a 2-to-1 hash using `merge()` function (e.g., for building a Merkle tree) and when we hash 8 field elements as a sequence of elements using `hash_elements()` function. However, this also means that our instantiation of Rescue Prime cannot be used in a stream mode as the number of elements to be hashed must be known upfront.
 
 The parameters used to instantiate the function are:
 * Field: 62-bit prime field with modulus 2^62 - 111 * 2^39 + 1.

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -2,7 +2,36 @@
 This crate contains modules with cryptographic operations needed in STARK proof generation and verification.
 
 ## Hash
-[Hash](src/hash) module defines a set of hash functions available for cryptographic operations. Currently, two hash functions are supported: BLAKE3 (with 192-bit and 256-bit output) and SHA3. Support of additional hash functions is planned, including arithmetization-friendly hash functions such as [Rescue](https://eprint.iacr.org/2020/1143).
+[Hash](src/hash) module defines a set of hash functions available for cryptographic operations. Currently, the following hash functions are supported:
+ 
+* SHA3 with 256-bit output.
+* BLAKE3 with either 256-bit or 192-bit output. The smaller output version can be used to reduce STARK proof size, however, it also reduces proof security level to 96 bits.
+* Rescue Prime over a 62-bit field with 248-bit output. Rescue is an arithmetization-friendly hash function which can be used as a building block in recursive proof composition. However, using this function is not yet supported by the Winterfell STARK prover and verifier.
+
+### Rescue hash function implementation
+Rescue hash function is implemented according to the Rescue Prime [specifications](https://eprint.iacr.org/2020/1143.pdf) with the following exception:
+* We set the number of rounds to 7, which implies a 40% security margin instead of the 50% margin used in the specifications (a 50% margin rounds up to 8 rounds).
+* When hashing a sequence of elements, we do not append Fp(1) followed by Fp(0) elements to the end of the sequence as padding. Instead, we initialize one of the capacity elements to the number of elements to be hashed, and pad the sequence with Fp(0) elements only.
+
+The parameters used to instantiate the function are:
+* Field: 62-bit prime field with modulus 2^62 - 111 * 2^39 + 1.
+* State width: 12 field elements.
+* Capacity size: 4 field elements.
+* Number of founds: 7.
+* S-Box degree: 3.
+
+The above parameters target 124-bit security level. The digest consists of four field elements and it can be serialized into 31 bytes (248 bits).
+
+### Hash function performance
+One of the core operations performed during STARK proof generation is construction of Merkle trees. We care greatly about building these trees as quickly as possible, and thus, for the purposes of STARK protocol, 2-to-1 hash operation (e.g., computing a hash of two 32-byte values) is especially important. The table below contains rough benchmarks for computing a 2-to-1 hash for all currently implemented hash functions.
+
+| CPU                      | BLAKE3_256 | SHA3_256 | RP62_248 |
+| ------------------------ | :--------: | :------: | :------: |
+| Core i9-9980KH @ 2.4 GHz | 66 ns      | 400 ns   | 6.6 us   |
+| Core i5-7300U @ 2.6 GHz  | 81 ns      | 540 ns   | 9.5 us   |
+| Core i5-4300U @ 1.9 GHz  | 106 ns     | 675 ns   | 13.9 us  |
+
+As can be seen from the table, BLAKE3 is by far the fastest hash function, while our implementation of Rescue Prime is roughly 100x slower than BLAKE3 and about 17x slower than SHA3.
 
 ## Merkle
 [Merkle](src/merkle) module contains an implementation of a Merkle tree which supports batch proof generation and verification. Batch proofs are based on the Octopus algorithm described [here](https://eprint.iacr.org/2017/933).

--- a/crypto/benches/hash.rs
+++ b/crypto/benches/hash.rs
@@ -4,31 +4,40 @@
 // LICENSE file in the root directory of this source tree.
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use math::fields::f128::BaseElement;
+use math::fields::f128;
 use winter_crypto::{
-    hashers::{Blake3_256, Sha3_256},
+    hashers::{Blake3_256, Rp62_248, Sha3_256},
     Hasher,
 };
 
-type Blake3 = Blake3_256<BaseElement>;
+type Blake3 = Blake3_256<f128::BaseElement>;
 type Blake3Digest = <Blake3 as Hasher>::Digest;
 
-type Sha3 = Sha3_256<BaseElement>;
+type Sha3 = Sha3_256<f128::BaseElement>;
 type Sha3Digest = <Sha3 as Hasher>::Digest;
 
-pub fn blake3(c: &mut Criterion) {
+type Rp62_248Digest = <Rp62_248 as Hasher>::Digest;
+
+fn blake3(c: &mut Criterion) {
     let v: [Blake3Digest; 2] = [Blake3::hash(&[1u8]), Blake3::hash(&[2u8])];
     c.bench_function("hash_blake3", |bench| {
         bench.iter(|| Blake3::merge(black_box(&v)))
     });
 }
 
-pub fn sha3(c: &mut Criterion) {
+fn sha3(c: &mut Criterion) {
     let v: [Sha3Digest; 2] = [Sha3::hash(&[1u8]), Sha3::hash(&[2u8])];
     c.bench_function("hash_sha3", |bench| {
         bench.iter(|| Sha3::merge(black_box(&v)))
     });
 }
 
-criterion_group!(hash_group, blake3, sha3);
+fn rescue248(c: &mut Criterion) {
+    let v: [Rp62_248Digest; 2] = [Rp62_248::hash(&[1u8]), Rp62_248::hash(&[2u8])];
+    c.bench_function("hash_rescue248", |bench| {
+        bench.iter(|| Rp62_248::merge(black_box(&v)))
+    });
+}
+
+criterion_group!(hash_group, blake3, sha3, rescue248);
 criterion_main!(hash_group);

--- a/crypto/src/hash/blake/mod.rs
+++ b/crypto/src/hash/blake/mod.rs
@@ -1,0 +1,113 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use super::{ByteDigest, ElementHasher, Hasher};
+use core::{convert::TryInto, fmt::Debug, marker::PhantomData};
+use math::{FieldElement, StarkField};
+
+#[cfg(test)]
+mod tests;
+
+// BLAKE3 256-BIT OUTPUT
+// ================================================================================================
+
+/// Implementation of the [Hasher](super::Hasher) trait for BLAKE3 hash function with 256-bit
+/// output.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Blake3_256<B: StarkField>(PhantomData<B>);
+
+impl<B: StarkField> Hasher for Blake3_256<B> {
+    type Digest = ByteDigest<32>;
+
+    fn hash(bytes: &[u8]) -> Self::Digest {
+        ByteDigest(*blake3::hash(bytes).as_bytes())
+    }
+
+    fn merge(values: &[Self::Digest; 2]) -> Self::Digest {
+        ByteDigest(blake3::hash(ByteDigest::digests_as_bytes(values)).into())
+    }
+
+    fn merge_with_int(seed: Self::Digest, value: u64) -> Self::Digest {
+        let mut data = [0; 40];
+        data[..32].copy_from_slice(&seed.0);
+        data[32..].copy_from_slice(&value.to_le_bytes());
+        ByteDigest(*blake3::hash(&data).as_bytes())
+    }
+}
+
+impl<B: StarkField> ElementHasher for Blake3_256<B> {
+    type BaseField = B;
+
+    fn hash_elements<E: FieldElement<BaseField = Self::BaseField>>(elements: &[E]) -> Self::Digest {
+        if B::IS_MALLEABLE {
+            // when elements are malleable, normalize their internal representation before hashing
+            let mut hasher = blake3::Hasher::new();
+            for element in elements.iter() {
+                let mut element = *element;
+                element.normalize();
+                hasher.update(element.as_bytes());
+            }
+            ByteDigest(*hasher.finalize().as_bytes())
+        } else {
+            // for non-malleable elements, hash them as is (in their internal representation)
+            let bytes = E::elements_as_bytes(elements);
+            ByteDigest(*blake3::hash(bytes).as_bytes())
+        }
+    }
+}
+
+// BLAKE3 192-BIT OUTPUT
+// ================================================================================================
+
+/// Implementation of the [Hasher](super::Hasher) trait for BLAKE3 hash function with 192-bit
+/// output.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Blake3_192<B: StarkField>(PhantomData<B>);
+
+impl<B: StarkField> Hasher for Blake3_192<B> {
+    type Digest = ByteDigest<24>;
+
+    fn hash(bytes: &[u8]) -> Self::Digest {
+        let result = blake3::hash(bytes);
+        ByteDigest(result.as_bytes()[..24].try_into().unwrap())
+    }
+
+    fn merge(values: &[Self::Digest; 2]) -> Self::Digest {
+        let result = blake3::hash(ByteDigest::digests_as_bytes(values));
+        ByteDigest(result.as_bytes()[..24].try_into().unwrap())
+    }
+
+    fn merge_with_int(seed: Self::Digest, value: u64) -> Self::Digest {
+        let mut data = [0; 32];
+        data[..24].copy_from_slice(&seed.0);
+        data[24..].copy_from_slice(&value.to_le_bytes());
+
+        let result = blake3::hash(&data);
+        ByteDigest(result.as_bytes()[..24].try_into().unwrap())
+    }
+}
+
+impl<B: StarkField> ElementHasher for Blake3_192<B> {
+    type BaseField = B;
+
+    fn hash_elements<E: FieldElement<BaseField = Self::BaseField>>(elements: &[E]) -> Self::Digest {
+        if B::IS_MALLEABLE {
+            // when elements are malleable, normalize their internal representation before hashing
+            let mut hasher = blake3::Hasher::new();
+            for element in elements.iter() {
+                let mut element = *element;
+                element.normalize();
+                hasher.update(element.as_bytes());
+            }
+            let result = hasher.finalize();
+            ByteDigest(result.as_bytes()[..24].try_into().unwrap())
+        } else {
+            // for non-malleable elements, hash them as is (in their internal representation)
+            let bytes = E::elements_as_bytes(elements);
+            let result = blake3::hash(bytes);
+            ByteDigest(result.as_bytes()[..24].try_into().unwrap())
+        }
+    }
+}

--- a/crypto/src/hash/blake/tests.rs
+++ b/crypto/src/hash/blake/tests.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use super::{Blake3_256, ElementHasher, Hasher};
+use math::{fields::f62::BaseElement, FieldElement};
+
+#[test]
+fn hash_padding() {
+    let b1 = [1_u8, 2, 3];
+    let b2 = [1_u8, 2, 3, 0];
+
+    // adding a zero bytes at the end of a byte string should result in a different hash
+    let r1 = Blake3_256::<BaseElement>::hash(&b1);
+    let r2 = Blake3_256::<BaseElement>::hash(&b2);
+    assert_ne!(r1, r2);
+}
+
+#[test]
+fn hash_elements_padding() {
+    let e1 = [BaseElement::rand(), BaseElement::rand()];
+    let e2 = [e1[0], e1[1], BaseElement::ZERO];
+
+    // adding a zero element at the end of a list of elements should result in a different hash
+    let r1 = Blake3_256::hash_elements(&e1);
+    let r2 = Blake3_256::hash_elements(&e2);
+    assert_ne!(r1, r2);
+}

--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -3,10 +3,15 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use core::{convert::TryInto, fmt::Debug, marker::PhantomData, slice};
+use core::{fmt::Debug, slice};
 use math::{FieldElement, StarkField};
-use sha3::Digest;
 use utils::{ByteReader, Deserializable, DeserializationError, Serializable};
+
+mod blake;
+pub use blake::{Blake3_192, Blake3_256};
+
+mod sha;
+pub use sha::Sha3_256;
 
 mod rescue;
 pub use rescue::Rp62_248;
@@ -62,152 +67,6 @@ pub trait ElementHasher: Hasher {
         E: FieldElement<BaseField = Self::BaseField>;
 }
 
-// BLAKE3
-// ================================================================================================
-
-/// Implementation of the [Hasher](super::Hasher) trait for BLAKE3 hash function with 256-bit
-/// output.
-#[derive(Debug, PartialEq, Eq)]
-pub struct Blake3_256<B: StarkField>(PhantomData<B>);
-
-impl<B: StarkField> Hasher for Blake3_256<B> {
-    type Digest = ByteDigest<32>;
-
-    fn hash(bytes: &[u8]) -> Self::Digest {
-        ByteDigest(*blake3::hash(bytes).as_bytes())
-    }
-
-    fn merge(values: &[Self::Digest; 2]) -> Self::Digest {
-        ByteDigest(blake3::hash(ByteDigest::digests_as_bytes(values)).into())
-    }
-
-    fn merge_with_int(seed: Self::Digest, value: u64) -> Self::Digest {
-        let mut data = [0; 40];
-        data[..32].copy_from_slice(&seed.0);
-        data[32..].copy_from_slice(&value.to_le_bytes());
-        ByteDigest(*blake3::hash(&data).as_bytes())
-    }
-}
-
-impl<B: StarkField> ElementHasher for Blake3_256<B> {
-    type BaseField = B;
-
-    fn hash_elements<E: FieldElement<BaseField = Self::BaseField>>(elements: &[E]) -> Self::Digest {
-        if B::IS_MALLEABLE {
-            // when elements are malleable, normalize their internal representation before hashing
-            let mut hasher = blake3::Hasher::new();
-            for element in elements.iter() {
-                let mut element = *element;
-                element.normalize();
-                hasher.update(element.as_bytes());
-            }
-            ByteDigest(*hasher.finalize().as_bytes())
-        } else {
-            // for non-malleable elements, hash them as is (in their internal representation)
-            let bytes = E::elements_as_bytes(elements);
-            ByteDigest(*blake3::hash(bytes).as_bytes())
-        }
-    }
-}
-
-/// Implementation of the [Hasher](super::Hasher) trait for BLAKE3 hash function with 192-bit
-/// output.
-#[derive(Debug, PartialEq, Eq)]
-pub struct Blake3_192<B: StarkField>(PhantomData<B>);
-
-impl<B: StarkField> Hasher for Blake3_192<B> {
-    type Digest = ByteDigest<24>;
-
-    fn hash(bytes: &[u8]) -> Self::Digest {
-        let result = blake3::hash(bytes);
-        ByteDigest(result.as_bytes()[..24].try_into().unwrap())
-    }
-
-    fn merge(values: &[Self::Digest; 2]) -> Self::Digest {
-        let result = blake3::hash(ByteDigest::digests_as_bytes(values));
-        ByteDigest(result.as_bytes()[..24].try_into().unwrap())
-    }
-
-    fn merge_with_int(seed: Self::Digest, value: u64) -> Self::Digest {
-        let mut data = [0; 32];
-        data[..24].copy_from_slice(&seed.0);
-        data[24..].copy_from_slice(&value.to_le_bytes());
-
-        let result = blake3::hash(&data);
-        ByteDigest(result.as_bytes()[..24].try_into().unwrap())
-    }
-}
-
-impl<B: StarkField> ElementHasher for Blake3_192<B> {
-    type BaseField = B;
-
-    fn hash_elements<E: FieldElement<BaseField = Self::BaseField>>(elements: &[E]) -> Self::Digest {
-        if B::IS_MALLEABLE {
-            // when elements are malleable, normalize their internal representation before hashing
-            let mut hasher = blake3::Hasher::new();
-            for element in elements.iter() {
-                let mut element = *element;
-                element.normalize();
-                hasher.update(element.as_bytes());
-            }
-            let result = hasher.finalize();
-            ByteDigest(result.as_bytes()[..24].try_into().unwrap())
-        } else {
-            // for non-malleable elements, hash them as is (in their internal representation)
-            let bytes = E::elements_as_bytes(elements);
-            let result = blake3::hash(bytes);
-            ByteDigest(result.as_bytes()[..24].try_into().unwrap())
-        }
-    }
-}
-
-// SHA3
-// ================================================================================================
-
-/// Implementation of the [Hasher](super::Hasher) trait for SHA3 hash function with 256-bit
-/// output.
-pub struct Sha3_256<B: StarkField>(PhantomData<B>);
-
-impl<B: StarkField> Hasher for Sha3_256<B> {
-    type Digest = ByteDigest<32>;
-
-    fn hash(bytes: &[u8]) -> Self::Digest {
-        ByteDigest(sha3::Sha3_256::digest(bytes).into())
-    }
-
-    fn merge(values: &[Self::Digest; 2]) -> Self::Digest {
-        ByteDigest(sha3::Sha3_256::digest(ByteDigest::digests_as_bytes(values)).into())
-    }
-
-    fn merge_with_int(seed: Self::Digest, value: u64) -> Self::Digest {
-        let mut data = [0; 40];
-        data[..32].copy_from_slice(&seed.0);
-        data[32..].copy_from_slice(&value.to_le_bytes());
-        ByteDigest(sha3::Sha3_256::digest(&data).into())
-    }
-}
-
-impl<B: StarkField> ElementHasher for Sha3_256<B> {
-    type BaseField = B;
-
-    fn hash_elements<E: FieldElement<BaseField = Self::BaseField>>(elements: &[E]) -> Self::Digest {
-        if B::IS_MALLEABLE {
-            // when elements are malleable, normalize their internal representation before hashing
-            let mut hasher = sha3::Sha3_256::new();
-            for element in elements.iter() {
-                let mut element = *element;
-                element.normalize();
-                hasher.update(element.as_bytes());
-            }
-            ByteDigest(hasher.finalize().into())
-        } else {
-            // for non-malleable elements, hash them as is (in their internal representation)
-            let bytes = E::elements_as_bytes(elements);
-            ByteDigest(sha3::Sha3_256::digest(bytes).into())
-        }
-    }
-}
-
 // BYTE DIGEST
 // ================================================================================================
 
@@ -220,7 +79,7 @@ impl<const N: usize> ByteDigest<N> {
     }
 
     #[inline(always)]
-    pub fn bytes_to_digests(bytes: &[[u8; N]]) -> &[ByteDigest<N>] {
+    pub fn bytes_as_digests(bytes: &[[u8; N]]) -> &[ByteDigest<N>] {
         let p = bytes.as_ptr();
         let len = bytes.len();
         unsafe { slice::from_raw_parts(p as *const ByteDigest<N>, len) }
@@ -256,52 +115,5 @@ impl<const N: usize> Serializable for ByteDigest<N> {
 impl<const N: usize> Deserializable for ByteDigest<N> {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         Ok(ByteDigest(source.read_u8_array()?))
-    }
-}
-
-// ELEMENT DIGEST
-// ================================================================================================
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct ElementDigest<B: StarkField, const N: usize>([B; N]);
-
-impl<B: StarkField, const N: usize> ElementDigest<B, N> {
-    pub fn new(value: [B; N]) -> Self {
-        Self(value)
-    }
-
-    #[inline(always)]
-    pub fn bytes_to_digests(_bytes: &[[u8; N]]) -> &[ElementDigest<B, N>] {
-        unimplemented!()
-    }
-
-    #[inline(always)]
-    pub fn digests_as_bytes(_digests: &[ElementDigest<B, N>]) -> &[u8] {
-        unimplemented!()
-    }
-}
-
-impl<B: StarkField, const N: usize> Default for ElementDigest<B, N> {
-    fn default() -> Self {
-        ElementDigest([B::default(); N])
-    }
-}
-
-impl<B: StarkField, const N: usize> AsRef<[u8]> for ElementDigest<B, N> {
-    #[inline(always)]
-    fn as_ref(&self) -> &[u8] {
-        unimplemented!()
-    }
-}
-
-impl<B: StarkField, const N: usize> Serializable for ElementDigest<B, N> {
-    fn write_into<W: utils::ByteWriter>(&self, _target: &mut W) {
-        unimplemented!()
-    }
-}
-
-impl<B: StarkField, const N: usize> Deserializable for ElementDigest<B, N> {
-    fn read_from<R: ByteReader>(_source: &mut R) -> Result<Self, DeserializationError> {
-        unimplemented!()
     }
 }

--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -8,6 +8,9 @@ use math::{FieldElement, StarkField};
 use sha3::Digest;
 use utils::{ByteReader, Deserializable, DeserializationError, Serializable};
 
+mod rescue;
+pub use rescue::Rp62_248;
+
 // HASHER TRAITS
 // ================================================================================================
 
@@ -205,7 +208,7 @@ impl<B: StarkField> ElementHasher for Sha3_256<B> {
     }
 }
 
-// DIGESTS
+// BYTE DIGEST
 // ================================================================================================
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -253,5 +256,52 @@ impl<const N: usize> Serializable for ByteDigest<N> {
 impl<const N: usize> Deserializable for ByteDigest<N> {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         Ok(ByteDigest(source.read_u8_array()?))
+    }
+}
+
+// ELEMENT DIGEST
+// ================================================================================================
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct ElementDigest<B: StarkField, const N: usize>([B; N]);
+
+impl<B: StarkField, const N: usize> ElementDigest<B, N> {
+    pub fn new(value: [B; N]) -> Self {
+        Self(value)
+    }
+
+    #[inline(always)]
+    pub fn bytes_to_digests(_bytes: &[[u8; N]]) -> &[ElementDigest<B, N>] {
+        unimplemented!()
+    }
+
+    #[inline(always)]
+    pub fn digests_as_bytes(_digests: &[ElementDigest<B, N>]) -> &[u8] {
+        unimplemented!()
+    }
+}
+
+impl<B: StarkField, const N: usize> Default for ElementDigest<B, N> {
+    fn default() -> Self {
+        ElementDigest([B::default(); N])
+    }
+}
+
+impl<B: StarkField, const N: usize> AsRef<[u8]> for ElementDigest<B, N> {
+    #[inline(always)]
+    fn as_ref(&self) -> &[u8] {
+        unimplemented!()
+    }
+}
+
+impl<B: StarkField, const N: usize> Serializable for ElementDigest<B, N> {
+    fn write_into<W: utils::ByteWriter>(&self, _target: &mut W) {
+        unimplemented!()
+    }
+}
+
+impl<B: StarkField, const N: usize> Deserializable for ElementDigest<B, N> {
+    fn read_from<R: ByteReader>(_source: &mut R) -> Result<Self, DeserializationError> {
+        unimplemented!()
     }
 }

--- a/crypto/src/hash/rescue/mod.rs
+++ b/crypto/src/hash/rescue/mod.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{ElementHasher, Hasher, StarkField};
+use super::{Digest, ElementHasher, Hasher, StarkField};
 
 mod rp62_248;
 pub use rp62_248::Rp62_248;

--- a/crypto/src/hash/rescue/mod.rs
+++ b/crypto/src/hash/rescue/mod.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use super::{ElementDigest, Hasher, StarkField};
+
+mod rp62_248;
+pub use rp62_248::Rp62_248;
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+#[inline(always)]
+fn exp_acc<B: StarkField, const N: usize, const M: usize>(base: [B; N], tail: [B; N]) -> [B; N] {
+    let mut result = base;
+    for _ in 0..M {
+        result.iter_mut().for_each(|r| *r = r.square());
+    }
+    result.iter_mut().zip(tail).for_each(|(r, t)| *r *= t);
+    result
+}

--- a/crypto/src/hash/rescue/mod.rs
+++ b/crypto/src/hash/rescue/mod.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{ElementDigest, Hasher, StarkField};
+use super::{ElementHasher, Hasher, StarkField};
 
 mod rp62_248;
 pub use rp62_248::Rp62_248;

--- a/crypto/src/hash/rescue/rp62_248.rs
+++ b/crypto/src/hash/rescue/rp62_248.rs
@@ -1,0 +1,573 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use super::{exp_acc, ElementDigest, Hasher};
+use core::convert::TryInto;
+use math::{fields::f62::BaseElement, FieldElement};
+
+// CONSTANTS
+// ================================================================================================
+
+const DIGEST_SIZE: usize = 4;
+const STATE_WIDTH: usize = 12;
+const NUM_ROUNDS: usize = 7;
+
+//const ALPHA: u32 = 3;
+//const INV_ALPHA: u64 = 3074416663688030891;
+
+const CYCLE_LENGTH: usize = 8;
+
+// HASHER IMPLEMENTATION
+// ================================================================================================
+
+pub struct Rp62_248();
+
+impl Hasher for Rp62_248 {
+    type Digest = ElementDigest<BaseElement, DIGEST_SIZE>;
+
+    fn hash(bytes: &[u8]) -> Self::Digest {
+        // TODO: implement properly
+        let mut state = [BaseElement::default(); STATE_WIDTH];
+        state[0] = BaseElement::new(bytes[0] as u64);
+
+        apply_permutation(&mut state);
+        ElementDigest(state[..4].try_into().unwrap())
+    }
+
+    fn merge(values: &[Self::Digest; 2]) -> Self::Digest {
+        let mut state = [BaseElement::default(); STATE_WIDTH];
+        state[..4].copy_from_slice(&values[0].0);
+        state[4..8].copy_from_slice(&values[1].0);
+
+        apply_permutation(&mut state);
+        ElementDigest(state[..4].try_into().unwrap())
+    }
+
+    fn merge_with_int(_seed: Self::Digest, _value: u64) -> Self::Digest {
+        unimplemented!()
+    }
+}
+
+// RESCUE PERMUTATION
+// ================================================================================================
+
+/// Applies Rescue-XLIX permutation to the provided state.
+fn apply_permutation(state: &mut [BaseElement; STATE_WIDTH]) {
+    // apply round function 7 times; this provides 128-bit security with 40% security margin
+    for i in 0..NUM_ROUNDS {
+        apply_round(state, i);
+    }
+}
+
+/// Rescue-XLIX round function;
+/// implementation based on algorithm 3 from <https://eprint.iacr.org/2020/1143.pdf>
+#[inline(always)]
+fn apply_round(state: &mut [BaseElement; STATE_WIDTH], round: usize) {
+    // apply first half of Rescue round
+    apply_sbox(state);
+    apply_mds(state);
+    state.iter_mut().zip(ARK1[round]).for_each(|(s, k)| *s += k);
+
+    // apply second half of Rescue round
+    apply_inv_sbox(state);
+    apply_mds(state);
+    state.iter_mut().zip(ARK2[round]).for_each(|(s, k)| *s += k);
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+#[inline(always)]
+fn apply_mds(state: &mut [BaseElement; STATE_WIDTH]) {
+    let mut result = [BaseElement::ZERO; STATE_WIDTH];
+    result.iter_mut().zip(MDS).for_each(|(r, mds_row)| {
+        state.iter().zip(mds_row).for_each(|(&s, m)| {
+            *r += m * s;
+        });
+    });
+    *state = result
+}
+
+#[inline(always)]
+fn apply_sbox(state: &mut [BaseElement; STATE_WIDTH]) {
+    state.iter_mut().for_each(|v| *v = v.cube())
+}
+
+#[inline(always)]
+fn apply_inv_sbox(state: &mut [BaseElement; STATE_WIDTH]) {
+    // compute base^3074416663688030891 using 69 multiplications per array element
+    // 3074416663688030891 = b10101010101010100001011010101010101010101010101010101010101011
+
+    // compute base^10
+    let mut t1 = *state;
+    t1.iter_mut().for_each(|t1| *t1 = t1.square());
+
+    // compute base^1010
+    let t2 = exp_acc::<BaseElement, STATE_WIDTH, 2>(t1, t1);
+
+    // compute base^10101010
+    let t4 = exp_acc::<BaseElement, STATE_WIDTH, 4>(t2, t2);
+
+    // compute base^1010101010101010
+    let t8 = exp_acc::<BaseElement, STATE_WIDTH, 8>(t4, t4);
+
+    // compute base^10101010101010100001010
+    let acc = exp_acc::<BaseElement, STATE_WIDTH, 7>(t8, t2);
+
+    // compute base^10101010101010100001011010101010101010
+    let acc = exp_acc::<BaseElement, STATE_WIDTH, 15>(acc, t8);
+
+    // compute base^101010101010101000010110101010101010101010101010101010
+    let acc = exp_acc::<BaseElement, STATE_WIDTH, 16>(acc, t8);
+
+    // compute base^10101010101010100001011010101010101010101010101010101010101010
+    let acc = exp_acc::<BaseElement, STATE_WIDTH, 8>(acc, t4);
+
+    // compute base^10101010101010100001011010101010101010101010101010101010101011
+    state.iter_mut().zip(acc).for_each(|(s, a)| *s *= a);
+}
+
+// MDS
+// ================================================================================================
+
+const MDS: [[BaseElement; STATE_WIDTH]; STATE_WIDTH] = [
+    [
+        BaseElement::new(3950144678237376122),
+        BaseElement::new(2690153189131774333),
+        BaseElement::new(936645784682382348),
+        BaseElement::new(3107191214132265415),
+        BaseElement::new(2603209838230440664),
+        BaseElement::new(1199396433148647196),
+        BaseElement::new(1282983482067326228),
+        BaseElement::new(461437407589395643),
+        BaseElement::new(2214977176974126410),
+        BaseElement::new(360795585898440),
+        BaseElement::new(4611624977880333167),
+        BaseElement::new(265720),
+    ],
+    [
+        BaseElement::new(3536793164176604955),
+        BaseElement::new(1911503332938627860),
+        BaseElement::new(3418675122760523340),
+        BaseElement::new(1504989930332511353),
+        BaseElement::new(2722575982003138843),
+        BaseElement::new(1431609872573058051),
+        BaseElement::new(1192456656548488631),
+        BaseElement::new(545546930229576032),
+        BaseElement::new(945223199513254881),
+        BaseElement::new(1241455355734630133),
+        BaseElement::new(4607295377894412377),
+        BaseElement::new(52955405230),
+    ],
+    [
+        BaseElement::new(4170851182034451356),
+        BaseElement::new(4049722115827050441),
+        BaseElement::new(2592958603203603955),
+        BaseElement::new(1591126261909367400),
+        BaseElement::new(1258275846807863107),
+        BaseElement::new(1998950167196902314),
+        BaseElement::new(3042201191319512244),
+        BaseElement::new(543039388605157758),
+        BaseElement::new(1398996793391337371),
+        BaseElement::new(4366181202594792993),
+        BaseElement::new(2647705527662157444),
+        BaseElement::new(9741692640081640),
+    ],
+    [
+        BaseElement::new(2734904247639408359),
+        BaseElement::new(4279587509601476247),
+        BaseElement::new(4485482368008952587),
+        BaseElement::new(3891839128198288856),
+        BaseElement::new(3605615068318190226),
+        BaseElement::new(4481033712623965820),
+        BaseElement::new(4511906145686918697),
+        BaseElement::new(3379942354449020806),
+        BaseElement::new(3990599459674901680),
+        BaseElement::new(3930378924631282611),
+        BaseElement::new(2736309679810514295),
+        BaseElement::new(4088651356677543187),
+    ],
+    [
+        BaseElement::new(842258110397353220),
+        BaseElement::new(3379876823114508085),
+        BaseElement::new(1075495666387844288),
+        BaseElement::new(2308322198399190449),
+        BaseElement::new(535073101119307124),
+        BaseElement::new(2549013922555968548),
+        BaseElement::new(2089967165864721761),
+        BaseElement::new(1833259538539094178),
+        BaseElement::new(1286299364399671252),
+        BaseElement::new(3116429868056012525),
+        BaseElement::new(3765145590440791140),
+        BaseElement::new(276983628385769116),
+    ],
+    [
+        BaseElement::new(1299560456850023050),
+        BaseElement::new(4414989737001639740),
+        BaseElement::new(627780834867342283),
+        BaseElement::new(1711770898052004155),
+        BaseElement::new(1979604523493335895),
+        BaseElement::new(33488920757262988),
+        BaseElement::new(3296083413419576217),
+        BaseElement::new(716111559512999319),
+        BaseElement::new(1748727787185165915),
+        BaseElement::new(2725007460252215875),
+        BaseElement::new(2185047820717910109),
+        BaseElement::new(2319951565550756140),
+    ],
+    [
+        BaseElement::new(4184625686841861769),
+        BaseElement::new(1784981074793151883),
+        BaseElement::new(502457291852703062),
+        BaseElement::new(345570060311611630),
+        BaseElement::new(2471821400707240604),
+        BaseElement::new(2133038110899525730),
+        BaseElement::new(939120245208093777),
+        BaseElement::new(4151312447988641414),
+        BaseElement::new(210626922136569504),
+        BaseElement::new(2121768124528492214),
+        BaseElement::new(3469035391047007665),
+        BaseElement::new(743768221345332434),
+    ],
+    [
+        BaseElement::new(2145694559473526100),
+        BaseElement::new(1632268183143575659),
+        BaseElement::new(440280249850363795),
+        BaseElement::new(1074260737240252344),
+        BaseElement::new(434235372443698697),
+        BaseElement::new(4579079558834190297),
+        BaseElement::new(507988595809300562),
+        BaseElement::new(746255436130103157),
+        BaseElement::new(1959107915115263608),
+        BaseElement::new(4030330146733953284),
+        BaseElement::new(3748621471482452510),
+        BaseElement::new(1760002751403551673),
+    ],
+    [
+        BaseElement::new(2299194066166806303),
+        BaseElement::new(2406031288159683129),
+        BaseElement::new(3724303300393675060),
+        BaseElement::new(3136303930848425791),
+        BaseElement::new(842217609243732235),
+        BaseElement::new(2433222065782096659),
+        BaseElement::new(1853915347332186193),
+        BaseElement::new(3565339054535487990),
+        BaseElement::new(3159752035320462032),
+        BaseElement::new(1001592926358592140),
+        BaseElement::new(1070575826169209928),
+        BaseElement::new(2177302522881920563),
+    ],
+    [
+        BaseElement::new(2207526749486243134),
+        BaseElement::new(4032720262691072240),
+        BaseElement::new(1260214313840482146),
+        BaseElement::new(3621152551536391331),
+        BaseElement::new(1609693674346558276),
+        BaseElement::new(1076797379868177960),
+        BaseElement::new(1050224695423079188),
+        BaseElement::new(1679887683779537233),
+        BaseElement::new(1053394941293588429),
+        BaseElement::new(2176319632402176708),
+        BaseElement::new(807051555764923088),
+        BaseElement::new(2483141537228001953),
+    ],
+    [
+        BaseElement::new(873986056056007361),
+        BaseElement::new(2985158312969304104),
+        BaseElement::new(2082576071668149043),
+        BaseElement::new(1607709264834493266),
+        BaseElement::new(1027130385873843589),
+        BaseElement::new(3876861839368848637),
+        BaseElement::new(2999813843878199730),
+        BaseElement::new(3252530728916107838),
+        BaseElement::new(4464640832314938694),
+        BaseElement::new(1978539358398864357),
+        BaseElement::new(3425590232595452442),
+        BaseElement::new(3706838041850115299),
+    ],
+    [
+        BaseElement::new(3407508207732360664),
+        BaseElement::new(2899952415584588394),
+        BaseElement::new(282047285293952955),
+        BaseElement::new(4147714396995528527),
+        BaseElement::new(1141786266584343815),
+        BaseElement::new(3523991864183271024),
+        BaseElement::new(1659008334442446407),
+        BaseElement::new(2857663046861472404),
+        BaseElement::new(1954265424153359502),
+        BaseElement::new(4018750979872307732),
+        BaseElement::new(494911809436924696),
+        BaseElement::new(1282149942051721903),
+    ],
+];
+
+// ROUND CONSTANTS
+// ================================================================================================
+pub const ARK1: [[BaseElement; STATE_WIDTH]; CYCLE_LENGTH] = [
+    [
+        BaseElement::new(2066114551762569441),
+        BaseElement::new(3806895469920197238),
+        BaseElement::new(4101271467144175579),
+        BaseElement::new(597783788093439290),
+        BaseElement::new(3459529549731874958),
+        BaseElement::new(3361732357449281221),
+        BaseElement::new(4510044102131299796),
+        BaseElement::new(2674251637583411151),
+        BaseElement::new(4589456981709905074),
+        BaseElement::new(97204927704726530),
+        BaseElement::new(3366467278170867590),
+        BaseElement::new(1661995649761352250),
+    ],
+    [
+        BaseElement::new(2552080730515318124),
+        BaseElement::new(4551129269607279176),
+        BaseElement::new(3896238353185798118),
+        BaseElement::new(4378451547412130464),
+        BaseElement::new(1120678946404787820),
+        BaseElement::new(3392815550656692052),
+        BaseElement::new(3397267446269039551),
+        BaseElement::new(2148161493216445570),
+        BaseElement::new(449851947043698998),
+        BaseElement::new(2745778316253333994),
+        BaseElement::new(3247100729373266485),
+        BaseElement::new(1474512661374883327),
+    ],
+    [
+        BaseElement::new(3875405236566248698),
+        BaseElement::new(3509172052827303011),
+        BaseElement::new(232674088014396347),
+        BaseElement::new(4189609763147780999),
+        BaseElement::new(3106901133683704323),
+        BaseElement::new(592695797873090171),
+        BaseElement::new(266738566669046215),
+        BaseElement::new(2668509039085882180),
+        BaseElement::new(950720373611234910),
+        BaseElement::new(1192091586747406812),
+        BaseElement::new(2245360993531047612),
+        BaseElement::new(2031514636218081872),
+    ],
+    [
+        BaseElement::new(2291456653144584105),
+        BaseElement::new(869259464485808552),
+        BaseElement::new(1154055231930493301),
+        BaseElement::new(1843073679205946182),
+        BaseElement::new(1748748883129851856),
+        BaseElement::new(4085632850766581010),
+        BaseElement::new(2907511654177734852),
+        BaseElement::new(1563252740420931271),
+        BaseElement::new(57166044462862224),
+        BaseElement::new(3237323403752048612),
+        BaseElement::new(4563484427236835576),
+        BaseElement::new(2956709587309713553),
+    ],
+    [
+        BaseElement::new(2157779262561212790),
+        BaseElement::new(2452020513593893218),
+        BaseElement::new(3051597722203497560),
+        BaseElement::new(3131962147511514023),
+        BaseElement::new(194930663253195526),
+        BaseElement::new(930794074695110797),
+        BaseElement::new(3616451697350340387),
+        BaseElement::new(1493869649774878568),
+        BaseElement::new(2790579710588613698),
+        BaseElement::new(4552593272704308029),
+        BaseElement::new(931863165972727433),
+        BaseElement::new(2628222466499909093),
+    ],
+    [
+        BaseElement::new(628982718083809865),
+        BaseElement::new(3809487906119235546),
+        BaseElement::new(1412055838972795717),
+        BaseElement::new(2702758340764464061),
+        BaseElement::new(643165380746471120),
+        BaseElement::new(1755475976486779630),
+        BaseElement::new(4322584783908582556),
+        BaseElement::new(2377752666356883186),
+        BaseElement::new(3806838324704149861),
+        BaseElement::new(3978620600887524391),
+        BaseElement::new(2546609133879704944),
+        BaseElement::new(3704323050566652251),
+    ],
+    [
+        BaseElement::new(364418616620607840),
+        BaseElement::new(557500673241722848),
+        BaseElement::new(2838167312179774894),
+        BaseElement::new(919171238566781484),
+        BaseElement::new(1810286722734245651),
+        BaseElement::new(2647811277753845608),
+        BaseElement::new(1083073358474695843),
+        BaseElement::new(2087740333294235353),
+        BaseElement::new(3237593972479805167),
+        BaseElement::new(2979012086287276314),
+        BaseElement::new(4247318354894968843),
+        BaseElement::new(4339035876293932168),
+    ],
+    [
+        BaseElement::new(637464443586979476),
+        BaseElement::new(2836759567512989604),
+        BaseElement::new(2810771120313048804),
+        BaseElement::new(933847926071662702),
+        BaseElement::new(3671300003323773082),
+        BaseElement::new(1302583912073804613),
+        BaseElement::new(1599597190376846885),
+        BaseElement::new(3744381265009855087),
+        BaseElement::new(2639095668805356140),
+        BaseElement::new(1001607423519830780),
+        BaseElement::new(2649493298619816104),
+        BaseElement::new(497568504817846927),
+    ],
+];
+
+pub const ARK2: [[BaseElement; STATE_WIDTH]; CYCLE_LENGTH] = [
+    [
+        BaseElement::new(3819036781602939606),
+        BaseElement::new(887046499825451011),
+        BaseElement::new(2129644207518417092),
+        BaseElement::new(2927054444958183703),
+        BaseElement::new(3938394192009721127),
+        BaseElement::new(4350492790583122386),
+        BaseElement::new(3932489874389553135),
+        BaseElement::new(2187735113981662094),
+        BaseElement::new(2707268329521558754),
+        BaseElement::new(1672475830798880457),
+        BaseElement::new(577661991381759440),
+        BaseElement::new(4202413457369478629),
+    ],
+    [
+        BaseElement::new(2386138289504492057),
+        BaseElement::new(3614836749985123032),
+        BaseElement::new(1959364639655691456),
+        BaseElement::new(3952161783467742979),
+        BaseElement::new(2113797503569123694),
+        BaseElement::new(2706761515468719677),
+        BaseElement::new(1408899580454624727),
+        BaseElement::new(1752562999883762712),
+        BaseElement::new(2699036399761024947),
+        BaseElement::new(2111974313315470120),
+        BaseElement::new(1945634303007041433),
+        BaseElement::new(603680138767490486),
+    ],
+    [
+        BaseElement::new(216541366065294490),
+        BaseElement::new(1663917238463860974),
+        BaseElement::new(3681161841551456227),
+        BaseElement::new(1463044976083347872),
+        BaseElement::new(4293067359825676566),
+        BaseElement::new(3701547299239100959),
+        BaseElement::new(2198012560927400476),
+        BaseElement::new(924090339017537873),
+        BaseElement::new(4592565695695653575),
+        BaseElement::new(2568652539159558382),
+        BaseElement::new(2556673802560280889),
+        BaseElement::new(2055200673419696274),
+    ],
+    [
+        BaseElement::new(675825972975288687),
+        BaseElement::new(157304917963529210),
+        BaseElement::new(2874195676109427150),
+        BaseElement::new(400733584567227315),
+        BaseElement::new(982698402204661622),
+        BaseElement::new(820183842893732317),
+        BaseElement::new(301881572013037058),
+        BaseElement::new(1963857632534980766),
+        BaseElement::new(4091993061963419897),
+        BaseElement::new(4102179200035343013),
+        BaseElement::new(886874507443125118),
+        BaseElement::new(1900379595653484868),
+    ],
+    [
+        BaseElement::new(663951223276314056),
+        BaseElement::new(3247862347650141921),
+        BaseElement::new(2405853211128575753),
+        BaseElement::new(2313821214725089833),
+        BaseElement::new(892865509580640652),
+        BaseElement::new(3786801988137677226),
+        BaseElement::new(1708051655041482785),
+        BaseElement::new(413367975786665969),
+        BaseElement::new(4184177931828745920),
+        BaseElement::new(1902978742415691889),
+        BaseElement::new(3457684352259258126),
+        BaseElement::new(2092600929857819767),
+    ],
+    [
+        BaseElement::new(3616150808336931771),
+        BaseElement::new(3206846600545625539),
+        BaseElement::new(3830153390371624940),
+        BaseElement::new(2654199900015314333),
+        BaseElement::new(783490214003335242),
+        BaseElement::new(3730076606034436027),
+        BaseElement::new(3784919641869206369),
+        BaseElement::new(2204748845493012644),
+        BaseElement::new(448185939031874189),
+        BaseElement::new(435945873799083567),
+        BaseElement::new(695310862494154666),
+        BaseElement::new(2112586212508747422),
+    ],
+    [
+        BaseElement::new(1802926915815728451),
+        BaseElement::new(2057340163436909216),
+        BaseElement::new(982232855844273391),
+        BaseElement::new(1559347186127685318),
+        BaseElement::new(1420221884912541505),
+        BaseElement::new(4213862187371016442),
+        BaseElement::new(476828620219460093),
+        BaseElement::new(4518037022029400598),
+        BaseElement::new(186346377116487094),
+        BaseElement::new(4479404873270208061),
+        BaseElement::new(3269764362972891817),
+        BaseElement::new(2929967273325723272),
+    ],
+    [
+        BaseElement::new(1555175681720018923),
+        BaseElement::new(2913517096498256645),
+        BaseElement::new(2119225001993504406),
+        BaseElement::new(1383803580992220774),
+        BaseElement::new(4395189003224844853),
+        BaseElement::new(248814153532786695),
+        BaseElement::new(3675667117284746347),
+        BaseElement::new(1077282323180186121),
+        BaseElement::new(2847878069549966282),
+        BaseElement::new(1830325602477655465),
+        BaseElement::new(3241765544416225076),
+        BaseElement::new(3803032785619635880),
+    ],
+];
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+
+    use super::{BaseElement, FieldElement, STATE_WIDTH};
+
+    #[test]
+    fn test_inv_sbox() {
+        const INV_ALPHA: u64 = 3074416663688030891;
+
+        let state: [BaseElement; STATE_WIDTH] = [
+            BaseElement::rand(),
+            BaseElement::rand(),
+            BaseElement::rand(),
+            BaseElement::rand(),
+            BaseElement::rand(),
+            BaseElement::rand(),
+            BaseElement::rand(),
+            BaseElement::rand(),
+            BaseElement::rand(),
+            BaseElement::rand(),
+            BaseElement::rand(),
+            BaseElement::rand(),
+        ];
+
+        let mut expected = state;
+        expected.iter_mut().for_each(|v| *v = v.exp(INV_ALPHA));
+
+        let mut actual = state;
+        super::apply_inv_sbox(&mut actual);
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/crypto/src/hash/rescue/rp62_248/digest.rs
+++ b/crypto/src/hash/rescue/rp62_248/digest.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use super::DIGEST_SIZE;
+use core::slice;
+use math::{fields::f62::BaseElement, FieldElement, StarkField};
+use utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
+
+// DIGEST TRAIT IMPLEMENTATIONS
+// ================================================================================================
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct ElementDigest([BaseElement; DIGEST_SIZE]);
+
+impl ElementDigest {
+    pub fn new(value: [BaseElement; DIGEST_SIZE]) -> Self {
+        Self(value)
+    }
+
+    pub fn as_elements(&self) -> &[BaseElement] {
+        &self.0
+    }
+
+    pub fn digests_as_elements(digests: &[Self]) -> &[BaseElement] {
+        let p = digests.as_ptr();
+        let len = digests.len() * DIGEST_SIZE;
+        unsafe { slice::from_raw_parts(p as *const BaseElement, len) }
+    }
+}
+
+impl Default for ElementDigest {
+    fn default() -> Self {
+        ElementDigest([BaseElement::default(); DIGEST_SIZE])
+    }
+}
+
+impl AsRef<[u8]> for ElementDigest {
+    #[inline(always)]
+    fn as_ref(&self) -> &[u8] {
+        BaseElement::elements_as_bytes(&self.0)
+    }
+}
+
+impl Serializable for ElementDigest {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        let v1 = self.0[0].as_int();
+        let v2 = self.0[1].as_int();
+        let v3 = self.0[2].as_int();
+        let v4 = self.0[3].as_int();
+
+        println!("v4 {} -> {:b}", v4, v4);
+        target.write_u64(v1 | (v2 << 62));
+        target.write_u64((v2 >> 2) | (v3 << 60));
+        target.write_u64((v3 >> 4) | (v4 << 58));
+        target.write_u8_slice(&(v4 >> 6).to_le_bytes()[..7]);
+    }
+}
+
+impl Deserializable for ElementDigest {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let v1 = source.read_u64()?;
+        let v2 = source.read_u64()?;
+        let v3 = source.read_u64()?;
+        let v4 = source.read_u32()?;
+        let v5 = source.read_u16()?;
+        let v6 = source.read_u8()?;
+
+        println!("{:b}", v3 >> 58);
+        println!("{:b}", ((v4 as u64) << 6));
+
+        let e1 = BaseElement::new(v1 & 0x3FFFFFFFFFFFFFFF);
+        let e2 = BaseElement::new(((v2 << 4) >> 2) | (v1 >> 62) & 0x3FFFFFFFFFFFFFFF);
+        let e3 = BaseElement::new(((v3 << 6) >> 2) | (v2 >> 60) & 0x3FFFFFFFFFFFFFFF);
+        let e4 =
+            BaseElement::new(v3 >> 58 | (v4 as u64) << 6 | (v5 as u64) << 38 | (v6 as u64) << 54);
+
+        Ok(Self([e1, e2, e3, e4]))
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+
+    use super::{BaseElement, ElementDigest, FieldElement};
+    use utils::{Deserializable, Serializable, SliceReader};
+
+    #[test]
+    fn digest_serialization() {
+        let d1 = ElementDigest([
+            BaseElement::rand(),
+            BaseElement::rand(),
+            BaseElement::rand(),
+            BaseElement::rand(),
+        ]);
+
+        let mut bytes = vec![];
+        d1.write_into(&mut bytes);
+        assert_eq!(31, bytes.len());
+
+        let mut reader = SliceReader::new(&bytes);
+        let d2 = ElementDigest::read_from(&mut reader).unwrap();
+
+        assert_eq!(d1, d2);
+    }
+}

--- a/crypto/src/hash/rescue/rp62_248/mod.rs
+++ b/crypto/src/hash/rescue/rp62_248/mod.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{exp_acc, ElementHasher, Hasher};
+use super::{exp_acc, Digest, ElementHasher, Hasher};
 use core::convert::TryInto;
 use math::{fields::f62::BaseElement, FieldElement, StarkField};
 

--- a/crypto/src/hash/rescue/rp62_248/mod.rs
+++ b/crypto/src/hash/rescue/rp62_248/mod.rs
@@ -46,10 +46,15 @@ const INV_ALPHA: u64 = 3074416663688030891;
 /// The hash function is implemented according to the Rescue Prime
 /// [specifications](https://eprint.iacr.org/2020/1143.pdf) with the following exception:
 /// * We set the number of rounds to 7, which implies a 40% security margin instead of the 50%
-///   margin used in the specifications (a 50% margin rounds up to 8 rounds).
+///   margin used in the specifications (a 50% margin rounds up to 8 rounds). The primary
+///   motivation for this is that having the number of rounds be one less than a power of two
+///   simplifies AIR design for computations involving the hash function.
 /// * When hashing a sequence of elements, we do not append Fp(1) followed by Fp(0) elements
 ///   to the end of the sequence as padding. Instead, we initialize one of the capacity elements
-///   to the number of elements to be hashed, and pad the sequence with Fp(0) elements only.
+///   to the number of elements to be hashed, and pad the sequence with Fp(0) elements only. This
+///   ensures consistency of hash outputs between different hashing methods (see section below).
+///   However, it also means that our instantiation of Rescue Prime cannot be used in a stream
+///   mode as the number of elements to be hashed must be known upfront.
 ///
 /// The parameters used to instantiate the function are:
 /// * Field: 62-bit prime field with modulus 2^62 - 111 * 2^39 + 1.

--- a/crypto/src/hash/rescue/rp62_248/tests.rs
+++ b/crypto/src/hash/rescue/rp62_248/tests.rs
@@ -1,0 +1,170 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use math::StarkField;
+
+use super::{
+    BaseElement, ElementDigest, ElementHasher, FieldElement, Hasher, Rp62_248, ALPHA, INV_ALPHA,
+    STATE_WIDTH,
+};
+use core::convert::TryInto;
+
+#[test]
+fn test_alphas() {
+    let e = BaseElement::rand();
+    let e_exp = e.exp(ALPHA.into());
+    assert_eq!(e, e_exp.exp(INV_ALPHA));
+}
+
+#[test]
+fn test_inv_sbox() {
+    let state: [BaseElement; STATE_WIDTH] = [
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+    ];
+
+    let mut expected = state;
+    expected.iter_mut().for_each(|v| *v = v.exp(INV_ALPHA));
+
+    let mut actual = state;
+    super::apply_inv_sbox(&mut actual);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn apply_permutation() {
+    let mut state: [BaseElement; STATE_WIDTH] = [
+        BaseElement::new(0),
+        BaseElement::new(1),
+        BaseElement::new(2),
+        BaseElement::new(3),
+        BaseElement::new(4),
+        BaseElement::new(5),
+        BaseElement::new(6),
+        BaseElement::new(7),
+        BaseElement::new(8),
+        BaseElement::new(9),
+        BaseElement::new(10),
+        BaseElement::new(11),
+    ];
+
+    super::apply_permutation(&mut state);
+
+    // expected values are obtained by executing sage reference implementation code
+    let expected = vec![
+        BaseElement::new(2176593392043442589),
+        BaseElement::new(3663362000910009411),
+        BaseElement::new(2446978550600442325),
+        BaseElement::new(4214718471639678996),
+        BaseElement::new(4179776369445579812),
+        BaseElement::new(2274316532403536457),
+        BaseElement::new(2336761070419368662),
+        BaseElement::new(3192888412646553651),
+        BaseElement::new(4092565229845701133),
+        BaseElement::new(753437048204208885),
+        BaseElement::new(4067414342325289862),
+        BaseElement::new(3516613610105678931),
+    ];
+
+    assert_eq!(expected, state);
+}
+
+#[test]
+fn hash_elements_vs_merge() {
+    let elements = [
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+    ];
+
+    let digests: [ElementDigest; 2] = [
+        ElementDigest::new(elements[..4].try_into().unwrap()),
+        ElementDigest::new(elements[4..].try_into().unwrap()),
+    ];
+
+    let m_result = Rp62_248::merge(&digests);
+    let h_result = Rp62_248::hash_elements(&elements);
+    assert_eq!(m_result, h_result);
+}
+
+#[test]
+fn hash_elements_vs_merge_with_int() {
+    let seed = ElementDigest::new([
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+        BaseElement::rand(),
+    ]);
+
+    // ----- value fits into a field element ------------------------------------------------------
+    let val = BaseElement::rand();
+    let m_result = Rp62_248::merge_with_int(seed, val.as_int());
+
+    let mut elements = seed.as_elements().to_vec();
+    elements.push(val);
+    let h_result = Rp62_248::hash_elements(&elements);
+
+    assert_eq!(m_result, h_result);
+
+    // ----- value does not fit into a field element ----------------------------------------------
+    let val = BaseElement::MODULUS + 2;
+    let m_result = Rp62_248::merge_with_int(seed, val);
+
+    let mut elements = seed.as_elements().to_vec();
+    elements.push(BaseElement::new(val));
+    elements.push(BaseElement::new(1));
+    let h_result = Rp62_248::hash_elements(&elements);
+
+    assert_eq!(m_result, h_result);
+}
+
+#[test]
+fn hash_padding() {
+    // adding a zero bytes at the end of a byte string should result in a different hash
+    let r1 = Rp62_248::hash(&[1_u8, 2, 3]);
+    let r2 = Rp62_248::hash(&[1_u8, 2, 3, 0]);
+    assert_ne!(r1, r2);
+
+    // same as above but with bigger inputs
+    let r1 = Rp62_248::hash(&[1_u8, 2, 3, 4, 5, 6]);
+    let r2 = Rp62_248::hash(&[1_u8, 2, 3, 4, 5, 6, 0]);
+    assert_ne!(r1, r2);
+
+    // same as above but with input splitting over two elements
+    let r1 = Rp62_248::hash(&[1_u8, 2, 3, 4, 5, 6, 7]);
+    let r2 = Rp62_248::hash(&[1_u8, 2, 3, 4, 5, 6, 7, 0]);
+    assert_ne!(r1, r2);
+
+    // same as above but with multiple zeros
+    let r1 = Rp62_248::hash(&[1_u8, 2, 3, 4, 5, 6, 7, 0, 0]);
+    let r2 = Rp62_248::hash(&[1_u8, 2, 3, 4, 5, 6, 7, 0, 0, 0, 0]);
+    assert_ne!(r1, r2);
+}
+
+#[test]
+fn hash_elements_padding() {
+    let e1 = [BaseElement::rand(), BaseElement::rand()];
+    let e2 = [e1[0], e1[1], BaseElement::ZERO];
+
+    let r1 = Rp62_248::hash_elements(&e1);
+    let r2 = Rp62_248::hash_elements(&e2);
+    assert_ne!(r1, r2);
+}

--- a/crypto/src/hash/sha/mod.rs
+++ b/crypto/src/hash/sha/mod.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use super::{ByteDigest, ElementHasher, Hasher};
+use core::marker::PhantomData;
+use math::{FieldElement, StarkField};
+use sha3::Digest;
+
+// SHA3 WITH 256-BIT OUTPUT
+// ================================================================================================
+
+/// Implementation of the [Hasher](super::Hasher) trait for SHA3 hash function with 256-bit
+/// output.
+pub struct Sha3_256<B: StarkField>(PhantomData<B>);
+
+impl<B: StarkField> Hasher for Sha3_256<B> {
+    type Digest = ByteDigest<32>;
+
+    fn hash(bytes: &[u8]) -> Self::Digest {
+        ByteDigest(sha3::Sha3_256::digest(bytes).into())
+    }
+
+    fn merge(values: &[Self::Digest; 2]) -> Self::Digest {
+        ByteDigest(sha3::Sha3_256::digest(ByteDigest::digests_as_bytes(values)).into())
+    }
+
+    fn merge_with_int(seed: Self::Digest, value: u64) -> Self::Digest {
+        let mut data = [0; 40];
+        data[..32].copy_from_slice(&seed.0);
+        data[32..].copy_from_slice(&value.to_le_bytes());
+        ByteDigest(sha3::Sha3_256::digest(&data).into())
+    }
+}
+
+impl<B: StarkField> ElementHasher for Sha3_256<B> {
+    type BaseField = B;
+
+    fn hash_elements<E: FieldElement<BaseField = Self::BaseField>>(elements: &[E]) -> Self::Digest {
+        if B::IS_MALLEABLE {
+            // when elements are malleable, normalize their internal representation before hashing
+            let mut hasher = sha3::Sha3_256::new();
+            for element in elements.iter() {
+                let mut element = *element;
+                element.normalize();
+                hasher.update(element.as_bytes());
+            }
+            ByteDigest(hasher.finalize().into())
+        } else {
+            // for non-malleable elements, hash them as is (in their internal representation)
+            let bytes = E::elements_as_bytes(elements);
+            ByteDigest(sha3::Sha3_256::digest(bytes).into())
+        }
+    }
+}

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -27,7 +27,7 @@ extern crate alloc;
 extern crate std;
 
 mod hash;
-pub use hash::{ElementHasher, Hasher};
+pub use hash::{Digest, ElementHasher, Hasher};
 pub mod hashers {
     //! Contains implementations of currently supported hash functions.
 

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -33,6 +33,7 @@ pub mod hashers {
 
     pub use super::hash::Blake3_192;
     pub use super::hash::Blake3_256;
+    pub use super::hash::Rp62_248;
     pub use super::hash::Sha3_256;
 }
 

--- a/crypto/src/merkle/tests.rs
+++ b/crypto/src/merkle/tests.rs
@@ -66,7 +66,7 @@ static LEAVES8: [[u8; 32]; 8] = [
 
 #[test]
 fn new_tree() {
-    let leaves = Digest256::bytes_to_digests(&LEAVES4).to_vec();
+    let leaves = Digest256::bytes_as_digests(&LEAVES4).to_vec();
     let tree = MerkleTree::<Blake3_256>::new(leaves.clone()).unwrap();
     assert_eq!(2, tree.depth());
     let root = hash_2x1(
@@ -75,7 +75,7 @@ fn new_tree() {
     );
     assert_eq!(&root, tree.root());
 
-    let leaves = Digest256::bytes_to_digests(&LEAVES8).to_vec();
+    let leaves = Digest256::bytes_as_digests(&LEAVES8).to_vec();
     let tree = MerkleTree::<Blake3_256>::new(leaves.clone()).unwrap();
     assert_eq!(3, tree.depth());
     let root = hash_2x1(
@@ -94,7 +94,7 @@ fn new_tree() {
 #[test]
 fn prove() {
     // depth 4
-    let leaves = Digest256::bytes_to_digests(&LEAVES4).to_vec();
+    let leaves = Digest256::bytes_as_digests(&LEAVES4).to_vec();
     let tree = MerkleTree::<Blake3_256>::new(leaves.clone()).unwrap();
 
     let proof = vec![leaves[1], leaves[0], hash_2x1(leaves[2], leaves[3])];
@@ -104,7 +104,7 @@ fn prove() {
     assert_eq!(proof, tree.prove(2).unwrap());
 
     // depth 5
-    let leaves = Digest256::bytes_to_digests(&LEAVES8).to_vec();
+    let leaves = Digest256::bytes_as_digests(&LEAVES8).to_vec();
     let tree = MerkleTree::<Blake3_256>::new(leaves.clone()).unwrap();
 
     let proof = vec![
@@ -133,7 +133,7 @@ fn prove() {
 #[test]
 fn verify() {
     // depth 4
-    let leaves = Digest256::bytes_to_digests(&LEAVES4).to_vec();
+    let leaves = Digest256::bytes_as_digests(&LEAVES4).to_vec();
     let tree = MerkleTree::<Blake3_256>::new(leaves).unwrap();
     let proof = tree.prove(1).unwrap();
     assert!(MerkleTree::<Blake3_256>::verify(*tree.root(), 1, &proof).is_ok());
@@ -142,7 +142,7 @@ fn verify() {
     assert!(MerkleTree::<Blake3_256>::verify(*tree.root(), 2, &proof).is_ok());
 
     // depth 5
-    let leaves = Digest256::bytes_to_digests(&LEAVES8).to_vec();
+    let leaves = Digest256::bytes_as_digests(&LEAVES8).to_vec();
     let tree = MerkleTree::<Blake3_256>::new(leaves).unwrap();
     let proof = tree.prove(1).unwrap();
     assert!(MerkleTree::<Blake3_256>::verify(*tree.root(), 1, &proof).is_ok());
@@ -153,7 +153,7 @@ fn verify() {
 
 #[test]
 fn prove_batch() {
-    let leaves = Digest256::bytes_to_digests(&LEAVES8).to_vec();
+    let leaves = Digest256::bytes_as_digests(&LEAVES8).to_vec();
     let tree = MerkleTree::<Blake3_256>::new(leaves.clone()).unwrap();
 
     // 1 index
@@ -209,7 +209,7 @@ fn prove_batch() {
 
 #[test]
 fn verify_batch() {
-    let leaves = Digest256::bytes_to_digests(&LEAVES8).to_vec();
+    let leaves = Digest256::bytes_as_digests(&LEAVES8).to_vec();
     let tree = MerkleTree::<Blake3_256>::new(leaves).unwrap();
 
     let proof = tree.prove_batch(&[1]).unwrap();
@@ -281,7 +281,7 @@ pub fn random_blake3_merkle_tree(
     leave_count: usize,
 ) -> impl Strategy<Value = MerkleTree<Blake3_256>> {
     prop::collection::vec(any::<[u8; 32]>(), leave_count).prop_map(|leaves| {
-        let leaves = Digest256::bytes_to_digests(&leaves).to_vec();
+        let leaves = Digest256::bytes_as_digests(&leaves).to_vec();
         MerkleTree::<Blake3_256>::new(leaves).unwrap()
     })
 }

--- a/crypto/src/random/mod.rs
+++ b/crypto/src/random/mod.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use crate::{errors::RandomCoinError, Hasher};
+use crate::{errors::RandomCoinError, Digest, Hasher};
 use core::{convert::TryInto, marker::PhantomData};
 use math::{FieldElement, StarkField};
 use utils::collections::Vec;
@@ -154,7 +154,7 @@ impl<B: StarkField, H: Hasher> RandomCoin<B, H> {
     /// assert!(coin.leading_zeros() >= 2);
     /// ```
     pub fn leading_zeros(&self) -> u32 {
-        let bytes = self.seed.as_ref();
+        let bytes = self.seed.as_bytes();
         let seed_head = u64::from_le_bytes(bytes[..8].try_into().unwrap());
         seed_head.trailing_zeros()
     }
@@ -163,7 +163,7 @@ impl<B: StarkField, H: Hasher> RandomCoin<B, H> {
     /// value if it is interpreted as an integer in big-endian byte order.
     pub fn check_leading_zeros(&self, value: u64) -> u32 {
         let new_seed = H::merge_with_int(self.seed, value);
-        let bytes = new_seed.as_ref();
+        let bytes = new_seed.as_bytes();
         let seed_head = u64::from_le_bytes(bytes[..8].try_into().unwrap());
         seed_head.trailing_zeros()
     }
@@ -183,7 +183,7 @@ impl<B: StarkField, H: Hasher> RandomCoin<B, H> {
         for _ in 0..200 {
             // get the next pseudo-random value and take the first ELEMENT_BYTES from it
             let value = self.next();
-            let bytes = &value.as_ref()[..E::ELEMENT_BYTES as usize];
+            let bytes = &value.as_bytes()[..E::ELEMENT_BYTES as usize];
 
             // check if the bytes can be converted into a valid field element; if they can,
             // return; otherwise try again
@@ -270,7 +270,7 @@ impl<B: StarkField, H: Hasher> RandomCoin<B, H> {
         let mut values = Vec::new();
         for _ in 0..1000 {
             // get the next pseudo-random value and read the first 8 bytes from it
-            let bytes: [u8; 8] = self.next().as_ref()[..8].try_into().unwrap();
+            let bytes: [u8; 8] = self.next().as_bytes()[..8].try_into().unwrap();
 
             // convert to integer and limit the integer to the number of bits which can fit
             // into the specified domain

--- a/examples/src/merkle/mod.rs
+++ b/examples/src/merkle/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 use log::debug;
 use std::time::Instant;
 use winterfell::{
-    crypto::MerkleTree,
+    crypto::{Digest, MerkleTree},
     math::{fields::f128::BaseElement, log2, FieldElement, StarkField},
     ProofOptions, StarkProof, VerifierError,
 };
@@ -62,7 +62,7 @@ impl MerkleExample {
         debug!(
             "Computed Merkle path from leaf {} to root {} in {} ms",
             index,
-            hex::encode(tree.root()),
+            hex::encode(tree.root().as_bytes()),
             now.elapsed().as_millis(),
         );
 

--- a/examples/src/utils/rescue.rs
+++ b/examples/src/utils/rescue.rs
@@ -6,7 +6,7 @@
 use crate::utils::{are_equal, EvaluationResult};
 use core::slice;
 use winterfell::{
-    crypto::Hasher,
+    crypto::{Digest, Hasher},
     math::{fields::f128::BaseElement, FieldElement},
     ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
 };
@@ -145,9 +145,12 @@ impl Hash {
     }
 }
 
-impl AsRef<[u8]> for Hash {
-    fn as_ref(&self) -> &[u8] {
-        BaseElement::elements_as_bytes(&self.0)
+impl Digest for Hash {
+    fn as_bytes(&self) -> [u8; 32] {
+        let bytes = BaseElement::elements_as_bytes(&self.0);
+        let mut result = [0; 32];
+        result[..bytes.len()].copy_from_slice(bytes);
+        result
     }
 }
 

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -50,7 +50,7 @@ impl<B: StarkField> FieldElement for QuadExtensionA<B> {
     type BaseField = B;
 
     const ELEMENT_BYTES: usize = B::ELEMENT_BYTES * 2;
-    const IS_MALLEABLE: bool = B::IS_MALLEABLE;
+    const IS_CANONICAL: bool = B::IS_CANONICAL;
     const ZERO: Self = Self(B::ZERO, B::ZERO);
     const ONE: Self = Self(B::ONE, B::ZERO);
 
@@ -118,11 +118,6 @@ impl<B: StarkField> FieldElement for QuadExtensionA<B> {
         // get twice the number of base elements, and re-interpret them as quad field elements
         let result = B::prng_vector(seed, n * 2);
         Self::base_to_quad_vector(result)
-    }
-
-    fn normalize(&mut self) {
-        self.0.normalize();
-        self.1.normalize();
     }
 
     fn as_base_elements(elements: &[Self]) -> &[Self::BaseField] {

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -78,7 +78,7 @@ impl FieldElement for BaseElement {
 
     const ELEMENT_BYTES: usize = ELEMENT_BYTES;
 
-    const IS_MALLEABLE: bool = false;
+    const IS_CANONICAL: bool = true;
 
     fn inv(self) -> Self {
         BaseElement(inv(self.0))
@@ -147,10 +147,6 @@ impl FieldElement for BaseElement {
         let range = Uniform::from(RANGE);
         let g = StdRng::from_seed(seed);
         g.sample_iter(range).take(n).map(BaseElement).collect()
-    }
-
-    fn normalize(&mut self) {
-        // do nothing since the internal and canonical representations are the same
     }
 
     fn as_base_elements(elements: &[Self]) -> &[Self::BaseField] {

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -99,14 +99,6 @@ impl FieldElement for BaseElement {
         Self::try_from(bytes).ok()
     }
 
-    fn elements_into_bytes(elements: Vec<Self>) -> Vec<u8> {
-        let mut v = core::mem::ManuallyDrop::new(elements);
-        let p = v.as_mut_ptr();
-        let len = v.len() * Self::ELEMENT_BYTES;
-        let cap = v.capacity() * Self::ELEMENT_BYTES;
-        unsafe { Vec::from_raw_parts(p as *mut u8, len, cap) }
-    }
-
     fn elements_as_bytes(elements: &[Self]) -> &[u8] {
         // TODO: take endianness into account
         let p = elements.as_ptr();
@@ -159,6 +151,10 @@ impl FieldElement for BaseElement {
 
     fn normalize(&mut self) {
         // do nothing since the internal and canonical representations are the same
+    }
+
+    fn as_base_elements(elements: &[Self]) -> &[Self::BaseField] {
+        elements
     }
 }
 

--- a/math/src/field/f128/tests.rs
+++ b/math/src/field/f128/tests.rs
@@ -145,24 +145,6 @@ fn test_g_is_2_exp_40_root() {
 // ================================================================================================
 
 #[test]
-fn elements_into_bytes() {
-    let source = vec![
-        BaseElement::new(1),
-        BaseElement::new(2),
-        BaseElement::new(3),
-        BaseElement::new(4),
-    ];
-
-    let expected: Vec<u8> = vec![
-        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0,
-    ];
-
-    assert_eq!(expected, BaseElement::elements_into_bytes(source));
-}
-
-#[test]
 fn elements_as_bytes() {
     let source = vec![
         BaseElement::new(1),

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -87,7 +87,7 @@ impl FieldElement for BaseElement {
     const ONE: Self = BaseElement::new(1);
 
     const ELEMENT_BYTES: usize = ELEMENT_BYTES;
-    const IS_MALLEABLE: bool = true;
+    const IS_CANONICAL: bool = false;
 
     fn exp(self, power: Self::PositiveInteger) -> Self {
         let mut b = self;
@@ -175,11 +175,6 @@ impl FieldElement for BaseElement {
         let range = Uniform::from(RANGE);
         let g = StdRng::from_seed(seed);
         g.sample_iter(range).take(n).map(BaseElement::new).collect()
-    }
-
-    #[inline(always)]
-    fn normalize(&mut self) {
-        self.0 = normalize(self.0)
     }
 
     fn as_base_elements(elements: &[Self]) -> &[Self::BaseField] {

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -128,14 +128,6 @@ impl FieldElement for BaseElement {
         Self::try_from(bytes).ok()
     }
 
-    fn elements_into_bytes(elements: Vec<Self>) -> Vec<u8> {
-        let mut v = core::mem::ManuallyDrop::new(elements);
-        let p = v.as_mut_ptr();
-        let len = v.len() * Self::ELEMENT_BYTES;
-        let cap = v.capacity() * Self::ELEMENT_BYTES;
-        unsafe { Vec::from_raw_parts(p as *mut u8, len, cap) }
-    }
-
     fn elements_as_bytes(elements: &[Self]) -> &[u8] {
         // TODO: take endianness into account
         let p = elements.as_ptr();
@@ -189,6 +181,10 @@ impl FieldElement for BaseElement {
     fn normalize(&mut self) {
         self.0 = normalize(self.0)
     }
+
+    fn as_base_elements(elements: &[Self]) -> &[Self::BaseField] {
+        elements
+    }
 }
 
 impl StarkField for BaseElement {
@@ -200,7 +196,7 @@ impl StarkField for BaseElement {
     /// sage: GF(MODULUS).order() \
     /// 4611624995532046337
     const MODULUS: Self::PositiveInteger = M;
-    const MODULUS_BITS: u32 = 64;
+    const MODULUS_BITS: u32 = 62;
 
     /// sage: GF(MODULUS).primitive_element() \
     /// 3

--- a/math/src/field/f62/tests.rs
+++ b/math/src/field/f62/tests.rs
@@ -163,24 +163,6 @@ fn try_from_slice() {
 }
 
 #[test]
-fn elements_into_bytes() {
-    let source = vec![
-        BaseElement::new(1),
-        BaseElement::new(2),
-        BaseElement::new(3),
-        BaseElement::new(4),
-    ];
-
-    let mut expected = vec![];
-    expected.extend_from_slice(&source[0].0.to_le_bytes());
-    expected.extend_from_slice(&source[1].0.to_le_bytes());
-    expected.extend_from_slice(&source[2].0.to_le_bytes());
-    expected.extend_from_slice(&source[3].0.to_le_bytes());
-
-    assert_eq!(expected, BaseElement::elements_into_bytes(source));
-}
-
-#[test]
 fn elements_as_bytes() {
     let source = vec![
         BaseElement::new(1),

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -144,26 +144,27 @@ pub trait FieldElement:
     fn rand() -> Self;
 
     /// Returns a field element if the set of bytes forms a valid field element, otherwise returns
-    /// None. The element is expected to be in canonical representation. This function is primarily
+    /// None.
+    ///
+    /// The element is expected to be in canonical representation. This function is primarily
     /// intended for sampling random field elements from a hash function output.
     fn from_random_bytes(bytes: &[u8]) -> Option<Self>;
 
     // SERIALIZATION / DESERIALIZATION
     // --------------------------------------------------------------------------------------------
 
-    /// Converts a vector of field elements into a vector of bytes. The elements may be in the
-    /// internal representation rather than in the canonical representation. This conversion is
-    /// intended to be zero-copy (i.e. by re-interpreting the underlying memory).
-    fn elements_into_bytes(elements: Vec<Self>) -> Vec<u8>;
-
-    /// Converts a list of elements into a list of bytes. The elements may be in the internal
-    /// representation rather than in the canonical representation. This conversion is intended
-    /// to be zero-copy (i.e. by re-interpreting the underlying memory).
+    /// Converts a list of elements into a list of bytes.
+    ///
+    /// The elements may be in the internal representation rather than in the canonical
+    /// representation. This conversion is intended to be zero-copy (i.e. by re-interpreting the
+    /// underlying memory).
     fn elements_as_bytes(elements: &[Self]) -> &[u8];
 
-    /// Converts a list of bytes into a list of field elements. The elements are assumed to
-    /// encoded in the internal representation rather than in the canonical representation. The
-    /// conversion is intended to be zero-copy (i.e. by re-interpreting the underlying memory).
+    /// Converts a list of bytes into a list of field elements.
+    ///
+    /// The elements are assumed to encoded in the internal representation rather than in the
+    /// canonical representation. The conversion is intended to be zero-copy (i.e. by
+    /// re-interpreting the underlying memory).
     ///
     /// # Errors
     /// An error is returned if:
@@ -198,6 +199,13 @@ pub trait FieldElement:
     /// Normalization is applicable only to malleable field elements; for non-malleable elements
     /// this is a no-op.
     fn normalize(&mut self);
+
+    /// Converts a list of field elements into a list of elements in the underlying base field.
+    ///
+    /// For base STARK fields, the input and output lists are the same. For extension field, the
+    /// output list will contain decompositions of each extension element into underlying base
+    /// elements.
+    fn as_base_elements(elements: &[Self]) -> &[Self::BaseField];
 }
 
 // STARK FIELD

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -75,9 +75,8 @@ pub trait FieldElement:
     /// Number of bytes needed to encode an element
     const ELEMENT_BYTES: usize;
 
-    /// True if internal representation of an element can be redundant - i.e., multiple
-    /// internal representations map to the same canonical representation.
-    const IS_MALLEABLE: bool;
+    /// True if internal representation of the element is the same as its canonical representation.
+    const IS_CANONICAL: bool;
 
     /// The additive identity.
     const ZERO: Self;
@@ -193,12 +192,6 @@ pub trait FieldElement:
 
     // UTILITIES
     // --------------------------------------------------------------------------------------------
-
-    /// Normalizes internal representation of this element.
-    ///
-    /// Normalization is applicable only to malleable field elements; for non-malleable elements
-    /// this is a no-op.
-    fn normalize(&mut self);
 
     /// Converts a list of field elements into a list of elements in the underlying base field.
     ///

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -155,7 +155,7 @@ pub trait Deserializable: Sized {
     /// * Bytes read from the `source` do not represent a valid value for `Self` for any of the
     ///   elements.
     ///
-    /// Note: if the error occurs, the reader is not rolled back to the state prior calling
+    /// Note: if the error occurs, the reader is not rolled back to the state prior to calling
     /// this function.
     fn read_batch_from<R: ByteReader>(
         source: &mut R,


### PR DESCRIPTION
This PR will implement high-performance instantiation of Rescue Prime hash function as described in #36 

- [x] Implement core Rescue Prime functions in `f62` field.
- [x] Implement `ElementDigest` struct for digests of arithmetization-friendly hash functions
- [x] Implement `Hasher` and `ElementHasher` traits for Rescue Prime
- [x] Add tests
- [x] Update docs