### PR TITLE
Preparation for publishing v0.2 to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,77 @@
+name: Publish
+
+on:
+  release:
+    types: [published] # Only publish to crates.io when we formally publish a release
+  # For more on how to formally release on Github, read https://help.github.com/en/articles/creating-releases
+
+jobs:
+  publish:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: ${{ matrix.rust }}
+    - uses: actions/checkout@master
+    - name: Login to crates.io
+      run: cargo login $CRATES_IO_TOKEN
+      env:
+        CRATES_IO_TOKEN: ${{ secrets.crates_io_token }} # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets
+    - name: Dry run publish winter-utils
+      run: cargo publish --dry-run --manifest-path utils/core/Cargo.toml
+    - name: Publish winter-utils
+      run: cargo publish --manifest-path utils/core/Cargo.toml
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+    - name: Dry run publish winter-rand-utils
+      run: cargo publish --dry-run --manifest-path utils/rand/Cargo.toml
+    - name: Publish winter-rand-utils
+      run: cargo publish --manifest-path utils/rand/Cargo.toml
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+    - name: Dry run publish winter-math
+      run: cargo publish --dry-run --manifest-path math/Cargo.toml
+    - name: Publish winter-math
+      run: cargo publish --manifest-path math/Cargo.toml
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+    - name: Dry run publish winter-crypto
+      run: cargo publish --dry-run --manifest-path crypto/Cargo.toml
+    - name: Publish winter-crypto
+      run: cargo publish --manifest-path crypto/Cargo.toml
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+    - name: Dry run publish winter-fri
+      run: cargo publish --dry-run --manifest-path fri/Cargo.toml
+    - name: Publish winter-fri
+      run: cargo publish --manifest-path fri/Cargo.toml
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+    - name: Dry run publish winter-air
+      run: cargo publish --dry-run --manifest-path air/Cargo.toml
+    - name: Publish winter-air
+      run: cargo publish --manifest-path air/Cargo.toml
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+    - name: Dry run publish winter-prover
+      run: cargo publish --dry-run --manifest-path prover/Cargo.toml
+    - name: Publish winter-prover
+      run: cargo publish --manifest-path prover/Cargo.toml
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+    - name: Dry run publish winter-verifier
+      run: cargo publish --dry-run --manifest-path verifier/Cargo.toml
+    - name: Publish winter-verifier
+      run: cargo publish --manifest-path verifier/Cargo.toml
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+    - name: Dry run publish winterfell
+      run: cargo publish --dry-run --manifest-path winterfell/Cargo.toml
+    - name: Publish winterfell
+      run: cargo publish --manifest-path winterfell/Cargo.toml
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.2.0 (2021-08-23)
+* Added `Blake3_192` as hash function option.
+* Implemented high-performance version of Rescue Prime hash function.
+* Removed `alloc` feature in favor of turning on `no_std` via `--no-default-features` flag only.
+* Moved `rand` dependency to `dev-dependencies` only and removed `hashbrown` dependency.
+* Increased min version of `rustc` to 1.54.
+
+## 0.1.0 (2021-08-03)
+* Initial release

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 <a href="https://github.com/novifinancial/winterfell/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
 <img src="https://github.com/novifinancial/winterfell/workflows/CI/badge.svg?branch=main">
 <a href="https://deps.rs/repo/github/novifinancial/winterfell"><img src="https://deps.rs/repo/github/novifinancial/winterfell/status.svg"></a>
-<img src="https://img.shields.io/badge/prover-rustc_1.51+-lightgray.svg">
-<img src="https://img.shields.io/badge/verifier-rustc_1.51+-lightgray.svg">
+<img src="https://img.shields.io/badge/prover-rustc_1.54+-lightgray.svg">
+<img src="https://img.shields.io/badge/verifier-rustc_1.54+-lightgray.svg">
+<a href="https://crates.io/crates/winterfell"><img src="https://img.shields.io/crates/v/winterfell"></a>
 
 A STARK prover and verifier for arbitrary computations.
 

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "winter-air"
-version = "0.1.0"
+version = "0.2.0"
 description = "AIR components for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
+documentation = "https://docs.rs/winter-air/0.2.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "arithmetization", "air"]
 edition = "2018"
@@ -18,13 +19,13 @@ default = ["std"]
 std = ["crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-utils = { version = "0.1", path = "../utils/core", package = "winter-utils", default-features = false }
-math = { version = "0.1", path = "../math", package = "winter-math", default-features = false }
-crypto = { version = "0.1", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.1", path = "../fri", package = "winter-fri", default-features = false }
+crypto = { version = "0.2", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.2", path = "../fri", package = "winter-fri", default-features = false }
+math = { version = "0.2", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.2", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
-rand-utils = { version = "0.1", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.2", path = "../utils/rand", package = "winter-rand-utils" }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "winter-crypto"
-version = "0.1.0"
+version = "0.2.0"
 description = "Cryptographic library for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
+documentation = "https://docs.rs/winter-crypto/0.2.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "merkle-tree", "hash"]
 edition = "2018"
@@ -28,12 +29,12 @@ concurrent = ["utils/concurrent", "std"]
 std = ["blake3/std", "math/std", "sha3/std", "utils/std"]
 
 [dependencies]
-utils = { version = "0.1", path = "../utils/core", package = "winter-utils", default-features = false }
-math = { version = "0.1", path = "../math", package = "winter-math", default-features = false }
 blake3 = { version = "1.0", default-features = false }
+math = { version = "0.2", path = "../math", package = "winter-math", default-features = false }
 sha3 = { version = "0.9", default-features = false }
+utils = { version = "0.2", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
 proptest = "1.0"
-rand-utils = { version = "0.1", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.2", path = "../utils/rand", package = "winter-rand-utils" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.1.0"
+version = "0.2.0"
 description = "Examples of using Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
@@ -25,8 +25,8 @@ default = ["std"]
 std = ["hex/std", "winterfell/std", "rand-utils"]
 
 [dependencies]
-winterfell = { path = "../winterfell", default-features = false }
-rand-utils = { version = "0.1", path = "../utils/rand", package = "winter-rand-utils", optional = true }
+winterfell = { version="0.2", path = "../winterfell", default-features = false }
+rand-utils = { version = "0.2", path = "../utils/rand", package = "winter-rand-utils", optional = true }
 hex = { version = "0.4", optional = true }
 log = { version = "0.4", default-features = false }
 blake3 = { version = "1.0", default-features = false }

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "winter-fri"
-version = "0.1.0"
+version = "0.2.0"
 description = "Implementation of FRI protocol for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
+documentation = "https://docs.rs/winter-fri/0.2.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "polynomial", "commitments"]
 edition = "2018"
@@ -27,10 +28,10 @@ default = ["std"]
 std = ["crypto/std", "math/std", "utils/std"]
 
 [dependencies]
-utils = { version = "0.1", path = "../utils/core", package = "winter-utils", default-features = false }
-math = { version = "0.1", path = "../math", package = "winter-math", default-features = false }
-crypto = { version = "0.1", path = "../crypto", package = "winter-crypto", default-features = false }
+crypto = { version = "0.2", path = "../crypto", package = "winter-crypto", default-features = false }
+math = { version = "0.2", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.2", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
-rand-utils = { version = "0.1", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.2", path = "../utils/rand", package = "winter-rand-utils" }

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "winter-math"
-version = "0.1.0"
+version = "0.2.0"
 description = "Math library for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
+documentation = "https://docs.rs/winter-math/0.2.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "finite-fields", "polynomials", "fft"]
 edition = "2018"
@@ -31,10 +32,10 @@ default = ["std"]
 std = ["utils/std"]
 
 [dependencies]
-utils = { version = "0.1", path = "../utils/core", package = "winter-utils", default-features = false }
+utils = { version = "0.2", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
 num-bigint = "0.4"
 proptest = "1.0"
-rand-utils = { version = "0.1", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.2", path = "../utils/rand", package = "winter-rand-utils" }

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "winter-prover"
-version = "0.1.0"
+version = "0.2.0"
 description = "Winterfell STARK prover"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
+documentation = "https://docs.rs/winter-prover/0.2.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "prover"]
 edition = "2018"
@@ -19,12 +20,12 @@ default = ["std"]
 std = ["air/std", "crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-utils = { version = "0.1", path = "../utils/core", package = "winter-utils", default-features = false }
-math = { version = "0.1", path = "../math", package = "winter-math", default-features = false }
-crypto = { version = "0.1", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.1", path = '../fri', package = "winter-fri", default-features = false }
-air = { version = "0.1", path = "../air", package = "winter-air", default-features = false }
+air = { version = "0.2", path = "../air", package = "winter-air", default-features = false }
+crypto = { version = "0.2", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.2", path = '../fri', package = "winter-fri", default-features = false }
 log = { version = "0.4", default-features = false }
+math = { version = "0.2", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.2", path = "../utils/core", package = "winter-utils", default-features = false }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/utils/core/Cargo.toml
+++ b/utils/core/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "winter-utils"
-version = "0.1.0"
+version = "0.2.0"
 description = "Utilities for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
+documentation = "https://docs.rs/winter-utils/0.2.0"
 categories = ["cryptography", "no-std"]
 keywords = ["serialization", "transmute"]
 edition = "2018"

--- a/utils/rand/Cargo.toml
+++ b/utils/rand/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "winter-rand-utils"
-version = "0.1.0"
+version = "0.2.0"
 description = "Random value generation utilities for Winterfell crates"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
+documentation = "https://docs.rs/winter-rand-utils/0.2.0"
 categories = ["cryptography"]
 keywords = ["rand"]
 edition = "2018"
@@ -14,7 +15,7 @@ edition = "2018"
 bench = false
 
 [dependencies]
-utils = { version = "0.1", path = "../core", package = "winter-utils" }
+utils = { version = "0.2", path = "../core", package = "winter-utils" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rand =  { version = "0.8" }

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "winter-verifier"
-version = "0.1.0"
+version = "0.2.0"
 description = "Winterfell STARK verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
+documentation = "https://docs.rs/winter-verifier/0.2.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "verifier"]
 edition = "2018"
@@ -18,11 +19,11 @@ default = ["std"]
 std = ["air/std", "crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-utils = { version = "0.1", path = "../utils/core", package = "winter-utils", default-features = false }
-math = { version = "0.1", path = "../math", package = "winter-math", default-features = false }
-crypto = { version = "0.1", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.1", path = "../fri", package = "winter-fri", default-features = false }
-air = { version = "0.1", path = "../air", package = "winter-air", default-features = false }
+air = { version = "0.2", path = "../air", package = "winter-air", default-features = false }
+crypto = { version = "0.2", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.2", path = "../fri", package = "winter-fri", default-features = false }
+math = { version = "0.2", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.2", path = "../utils/core", package = "winter-utils", default-features = false }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/winterfell/Cargo.toml
+++ b/winterfell/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "winterfell"
-version = "0.1.0"
+version = "0.2.0"
 description = "Winterfell STARK prover and verifier"
 authors = ["winterfell contributors"]
 readme = "../README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
+documentation = "https://docs.rs/winterfell/0.2.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "prover", "verifier"]
 edition = "2018"
@@ -19,8 +20,8 @@ default = ["std"]
 std = ["prover/std", "verifier/std"]
 
 [dependencies]
-prover = { version = "0.1", path = "../prover", package = "winter-prover", default-features = false }
-verifier = { version = "0.1", path = "../verifier", package = "winter-verifier", default-features = false }
+prover = { version = "0.2", path = "../prover", package = "winter-prover", default-features = false }
+verifier = { version = "0.2", path = "../verifier", package = "winter-verifier", default-features = false }
 
 # Allow math in docs
 [package.metadata.docs.rs]


### PR DESCRIPTION
This PR prepares all crates for publishing v0.2 version of all crates to crates.io

- [x] Update manifest files (updated version, added `documentation` field)
- [x] Update badges in the main README
- [x] Add CHANGELOG