### PR TITLE
Fix cubic extension

### DIFF
--- a/crypto/src/random/mod.rs
+++ b/crypto/src/random/mod.rs
@@ -174,13 +174,13 @@ impl<B: StarkField, H: Hasher> RandomCoin<B, H> {
     /// Returns the next pseudo-random field element.
     ///
     /// # Errors
-    /// Returns an error if a valid field element could not be generated after 100 calls to the
+    /// Returns an error if a valid field element could not be generated after 1000 calls to the
     /// PRNG.
     pub fn draw<E>(&mut self) -> Result<E, RandomCoinError>
     where
         E: FieldElement<BaseField = B>,
     {
-        for _ in 0..200 {
+        for _ in 0..1000 {
             // get the next pseudo-random value and take the first ELEMENT_BYTES from it
             let value = self.next();
             let bytes = &value.as_bytes()[..E::ELEMENT_BYTES as usize];
@@ -192,7 +192,7 @@ impl<B: StarkField, H: Hasher> RandomCoin<B, H> {
             }
         }
 
-        Err(RandomCoinError::FailedToDrawFieldElement(100))
+        Err(RandomCoinError::FailedToDrawFieldElement(1000))
     }
 
     /// Returns the next pair of pseudo-random field elements.

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -206,7 +206,7 @@ impl Serializable for FriProof {
         }
 
         // write remainder
-        target.write_u8(self.remainder.len().trailing_zeros() as u8);
+        target.write_u16(self.remainder.len() as u16);
         target.write_u8_slice(&self.remainder);
 
         // write number of partitions
@@ -225,7 +225,7 @@ impl Deserializable for FriProof {
         let layers = FriProofLayer::read_batch_from(source, num_layers)?;
 
         // read remainder
-        let remainder_bytes = 2usize.pow(source.read_u8()? as u32);
+        let remainder_bytes = source.read_u16()? as usize;
         let remainder = source.read_u8_vec(remainder_bytes)?;
 
         // read number of partitions


### PR DESCRIPTION
There are currently two issues when proving with field extensions:

- the first one, rather minor, is when sampling from the public coin. It may happen for cubic extension that we run out of trials by lack of luck. Increasing the number of mentioned trials before outputting an error solved this.
- the second one is with respect to the cubic extension. Currently, FriProof serialization is expecting a power-of-two remainder length, which is not the case when proving in the cubic extension. The second commit fixes this.

Both errors are visible on my temporary branch https://github.com/Nashtare/winterfell/tree/f62-example where I added an example of Fibonacci with `f62`, followed by the two fixes above (go back in the history when running `./target/release/winterfell -e 3 fib-f62` to see the actual errors prior fix)