### PR TITLE
Fix some typos

### DIFF
--- a/air/src/air/transition/mod.rs
+++ b/air/src/air/transition/mod.rs
@@ -23,7 +23,7 @@ const MIN_CYCLE_LENGTH: usize = 2;
 /// `evaluation` table by the [Air::evaluate_transition()](crate::Air::evaluate_transition)
 /// function.
 ///
-/// A transition constraint is described by a ration function of the form $\frac{C(x)}{z(x)}$,
+/// A transition constraint is described by a rational function of the form $\frac{C(x)}{z(x)}$,
 /// where:
 /// * $C(x)$ is the constraint polynomial.
 /// * $z(x)$ is the constraint divisor polynomial.

--- a/air/src/proof/context.rs
+++ b/air/src/proof/context.rs
@@ -149,7 +149,7 @@ impl Deserializable for Context {
         let num_modulus_bytes = source.read_u8()? as usize;
         if num_modulus_bytes == 0 {
             return Err(DeserializationError::InvalidValue(
-                "filed modulus cannot be an empty value".to_string(),
+                "field modulus cannot be an empty value".to_string(),
             ));
         }
         let field_modulus_bytes = source.read_u8_vec(num_modulus_bytes)?;

--- a/crypto/src/hash/rescue/rp62_248/mod.rs
+++ b/crypto/src/hash/rescue/rp62_248/mod.rs
@@ -127,7 +127,7 @@ impl Hasher for Rp62_248 {
                 buf[chunk_len] = 1;
             }
 
-            // convert the bytes into a filed element and absorb it into the rate portion of the
+            // convert the bytes into a field element and absorb it into the rate portion of the
             // state; if the rate is filled up, apply the Rescue permutation and start absorbing
             // again from zero index.
             state[i] += BaseElement::new(u64::from_le_bytes(buf));

--- a/crypto/src/hash/rescue/rp64_256/mod.rs
+++ b/crypto/src/hash/rescue/rp64_256/mod.rs
@@ -127,7 +127,7 @@ impl Hasher for Rp64_256 {
                 buf[chunk_len] = 1;
             }
 
-            // convert the bytes into a filed element and absorb it into the rate portion of the
+            // convert the bytes into a field element and absorb it into the rate portion of the
             // state; if the rate is filled up, apply the Rescue permutation and start absorbing
             // again from zero index.
             state[i] += BaseElement::new(u64::from_le_bytes(buf));

--- a/fri/src/folding/mod.rs
+++ b/fri/src/folding/mod.rs
@@ -32,7 +32,7 @@ use utils::{collections::Vec, iter_mut, uninit_vector};
 /// - evaluate f'(x) on a domain which consists of x^4 from the original domain (and thus is
 ///   1/4 the size).
 ///
-/// However, the reduction is preformed without converting the polynomials into coefficient form.
+/// However, the reduction is performed without converting the polynomials into coefficient form.
 /// That is, we can go directly form evaluations to folded evaluations. For this, for each
 /// evaluation in the folded domain, we need `N` evaluations in the source domain. For example,
 /// for the case of `N` = 4, to compute the evaluation of *f'*(x) we need to have evaluations of

--- a/fri/src/prover/mod.rs
+++ b/fri/src/prover/mod.rs
@@ -33,7 +33,7 @@ mod tests;
 /// The prover is parametrized with the following types:
 ///
 /// * `B` specifies the base field of the STARK protocol.
-/// * `E` specifies the filed in which the FRI protocol is executed. This can be the same as the
+/// * `E` specifies the field in which the FRI protocol is executed. This can be the same as the
 ///   base field `B`, but it can also be an extension of the base field in cases when the base
 ///   field is too small to provide desired security level for the FRI protocol.
 /// * `C` specifies the type used to simulate prover-verifier interaction.

--- a/fri/src/verifier/mod.rs
+++ b/fri/src/verifier/mod.rs
@@ -25,7 +25,7 @@ pub use channel::{DefaultVerifierChannel, VerifierChannel};
 /// The verifier is parametrized by the following types:
 ///
 /// * `B` specifies the base field of the STARK protocol.
-/// * `E` specifies the filed in which the FRI protocol is executed. This can be the same as the
+/// * `E` specifies the field in which the FRI protocol is executed. This can be the same as the
 ///   base field `B`, but it can also be an extension of the base field in cases when the base
 ///   field is too small to provide desired security level for the FRI protocol.
 /// * `C` specifies the type used to simulate prover-verifier interaction. This type is used

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -55,7 +55,7 @@ pub struct BaseElement(u128);
 
 impl BaseElement {
     /// Creates a new field element from a u128 value. If the value is greater than or equal to
-    /// the field modulus, modular reduction is silently preformed. This function can also be used
+    /// the field modulus, modular reduction is silently performed. This function can also be used
     /// to initialize constants.
     pub const fn new(value: u128) -> Self {
         BaseElement(if value < M { value } else { value - M })
@@ -285,36 +285,36 @@ impl ExtensibleField<3> for BaseElement {
 // ================================================================================================
 
 impl From<u128> for BaseElement {
-    /// Converts a 128-bit value into a filed element. If the value is greater than or equal to
-    /// the field modulus, modular reduction is silently preformed.
+    /// Converts a 128-bit value into a field element. If the value is greater than or equal to
+    /// the field modulus, modular reduction is silently performed.
     fn from(value: u128) -> Self {
         BaseElement::new(value)
     }
 }
 
 impl From<u64> for BaseElement {
-    /// Converts a 64-bit value into a filed element.
+    /// Converts a 64-bit value into a field element.
     fn from(value: u64) -> Self {
         BaseElement(value as u128)
     }
 }
 
 impl From<u32> for BaseElement {
-    /// Converts a 32-bit value into a filed element.
+    /// Converts a 32-bit value into a field element.
     fn from(value: u32) -> Self {
         BaseElement(value as u128)
     }
 }
 
 impl From<u16> for BaseElement {
-    /// Converts a 16-bit value into a filed element.
+    /// Converts a 16-bit value into a field element.
     fn from(value: u16) -> Self {
         BaseElement(value as u128)
     }
 }
 
 impl From<u8> for BaseElement {
-    /// Converts an 8-bit value into a filed element.
+    /// Converts an 8-bit value into a field element.
     fn from(value: u8) -> Self {
         BaseElement(value as u128)
     }
@@ -323,7 +323,7 @@ impl From<u8> for BaseElement {
 impl From<[u8; 16]> for BaseElement {
     /// Converts the value encoded in an array of 16 bytes into a field element. The bytes
     /// are assumed to be in little-endian byte order. If the value is greater than or equal
-    /// to the field modulus, modular reduction is silently preformed.
+    /// to the field modulus, modular reduction is silently performed.
     fn from(bytes: [u8; 16]) -> Self {
         let value = u128::from_le_bytes(bytes);
         BaseElement::from(value)

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -357,8 +357,8 @@ impl ExtensibleField<3> for BaseElement {
 // ================================================================================================
 
 impl From<u128> for BaseElement {
-    /// Converts a 128-bit value into a filed element. If the value is greater than or equal to
-    /// the field modulus, modular reduction is silently preformed.
+    /// Converts a 128-bit value into a field element. If the value is greater than or equal to
+    /// the field modulus, modular reduction is silently performed.
     fn from(value: u128) -> Self {
         // make sure the value is < 4M^2 - 4M + 1; this is overly conservative and a single
         // subtraction of (M * 2^65) should be enough, but this needs to be proven
@@ -379,29 +379,29 @@ impl From<u128> for BaseElement {
 }
 
 impl From<u64> for BaseElement {
-    /// Converts a 64-bit value into a filed element. If the value is greater than or equal to
-    /// the field modulus, modular reduction is silently preformed.
+    /// Converts a 64-bit value into a field element. If the value is greater than or equal to
+    /// the field modulus, modular reduction is silently performed.
     fn from(value: u64) -> Self {
         BaseElement::new(value)
     }
 }
 
 impl From<u32> for BaseElement {
-    /// Converts a 32-bit value into a filed element.
+    /// Converts a 32-bit value into a field element.
     fn from(value: u32) -> Self {
         BaseElement::new(value as u64)
     }
 }
 
 impl From<u16> for BaseElement {
-    /// Converts a 16-bit value into a filed element.
+    /// Converts a 16-bit value into a field element.
     fn from(value: u16) -> Self {
         BaseElement::new(value as u64)
     }
 }
 
 impl From<u8> for BaseElement {
-    /// Converts an 8-bit value into a filed element.
+    /// Converts an 8-bit value into a field element.
     fn from(value: u8) -> Self {
         BaseElement::new(value as u64)
     }
@@ -411,7 +411,7 @@ impl From<[u8; 8]> for BaseElement {
     /// Converts the value encoded in an array of 8 bytes into a field element. The bytes are
     /// assumed to encode the element in the canonical representation in little-endian byte order.
     /// If the value is greater than or equal to the field modulus, modular reduction is silently
-    /// preformed.
+    /// performed.
     fn from(bytes: [u8; 8]) -> Self {
         let value = u64::from_le_bytes(bytes);
         BaseElement::new(value)

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -59,7 +59,7 @@ pub struct BaseElement(u64);
 
 impl BaseElement {
     /// Creates a new field element from the provided `value`. If the value is greater than or
-    /// equal to the field modulus, modular reduction is silently preformed.
+    /// equal to the field modulus, modular reduction is silently performed.
     pub const fn new(value: u64) -> Self {
         Self(value % M)
     }
@@ -428,37 +428,37 @@ impl ExtensibleField<3> for BaseElement {
 // ================================================================================================
 
 impl From<u128> for BaseElement {
-    /// Converts a 128-bit value into a filed element. If the value is greater than or equal to
-    /// the field modulus, modular reduction is silently preformed.
+    /// Converts a 128-bit value into a field element. If the value is greater than or equal to
+    /// the field modulus, modular reduction is silently performed.
     fn from(value: u128) -> Self {
         Self(mod_reduce(value))
     }
 }
 
 impl From<u64> for BaseElement {
-    /// Converts a 64-bit value into a filed element. If the value is greater than or equal to
-    /// the field modulus, modular reduction is silently preformed.
+    /// Converts a 64-bit value into a field element. If the value is greater than or equal to
+    /// the field modulus, modular reduction is silently performed.
     fn from(value: u64) -> Self {
         Self::new(value)
     }
 }
 
 impl From<u32> for BaseElement {
-    /// Converts a 32-bit value into a filed element.
+    /// Converts a 32-bit value into a field element.
     fn from(value: u32) -> Self {
         Self::new(value as u64)
     }
 }
 
 impl From<u16> for BaseElement {
-    /// Converts a 16-bit value into a filed element.
+    /// Converts a 16-bit value into a field element.
     fn from(value: u16) -> Self {
         Self::new(value as u64)
     }
 }
 
 impl From<u8> for BaseElement {
-    /// Converts an 8-bit value into a filed element.
+    /// Converts an 8-bit value into a field element.
     fn from(value: u8) -> Self {
         Self::new(value as u64)
     }
@@ -468,7 +468,7 @@ impl From<[u8; 8]> for BaseElement {
     /// Converts the value encoded in an array of 8 bytes into a field element. The bytes are
     /// assumed to encode the element in the canonical representation in little-endian byte order.
     /// If the value is greater than or equal to the field modulus, modular reduction is silently
-    /// preformed.
+    /// performed.
     fn from(bytes: [u8; 8]) -> Self {
         let value = u64::from_le_bytes(bytes);
         Self::new(value)

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -25,7 +25,7 @@ use utils::{
 /// Moreover, it defines interfaces for serializing and deserializing field elements.
 ///
 /// The elements could be in a prime field or an extension of a prime field. Currently, only
-/// quadratic field extensions are supported.
+/// quadratic and cubic field extensions are supported.
 pub trait FieldElement:
     Copy
     + Clone
@@ -192,7 +192,7 @@ pub trait FieldElement:
 ///
 /// A STARK-friendly field is defined as a prime field with high two-addicity. That is, the
 /// the modulus of the field should be a prime number of the form `k` * 2^`n` + 1 (a Proth prime),
-/// where `n` is relatively larger (e.g., greater than 32).
+/// where `n` is relatively large (e.g., greater than 32).
 pub trait StarkField: FieldElement<BaseField = Self> {
     /// Prime modulus of the field. Must be of the form `k` * 2^`n` + 1 (a Proth prime).
     /// This ensures that the field has high 2-adicity.
@@ -236,7 +236,7 @@ pub trait StarkField: FieldElement<BaseField = Self> {
 // EXTENSIBLE FIELD
 // ================================================================================================
 
-/// Defined basic arithmetic in an extension of a StarkField of a given degree.
+/// Defines basic arithmetic in an extension of a StarkField of a given degree.
 ///
 /// This trait defines how to perform multiplication and compute a Frobenius automorphisms of an
 /// element in an extension of degree N for a given [StarkField]. It as assumed that an element in


### PR DESCRIPTION
I didn't attach it to the last PR (and I'm not sure it deserves a PR honestly) but here are some typo fixes, mostly from `winter_math`.
There is a similar typo in the Changelog (`filed` -> `field`) but I didn't touch it, as I wasn't sure if I could change previous entries of the Changelog.