### PR TITLE
Prover trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 * Added `f64` field.
 * Added support for cubic field extensions.
 * Added an implementation of Rescue Prime hash function in `f64` field.
-* Switched to Rust 2021 and increased min version of `rustc` to 1.57
+* Switched to Rust 2021 and increased min version of `rustc` to 1.57.
+* [BREAKING] Renamed `Air::BaseElement` to `Air::BaseField`.
+* [BREAKING] Replaced `prover::prove()` function with `Prover` trait.
+* [BREAKING] Split `ExecutionTrace` struct into `Trace` trait and `TraceTable` struct.
 
 ## 0.2.0 (2021-08-23)
 * Added `Blake3_192` as hash function option.

--- a/air/README.md
+++ b/air/README.md
@@ -12,7 +12,7 @@ Coming up with efficient arithmetizations for computations is highly non-trivial
 
 To define AIR for a given computation, you'll need to implement the `Air` trait which involves the following:
 
-1. Define base field for your computation via the `BaseElement` associated type (see [math crate](../math) for available field options).
+1. Define base field for your computation via the `BaseField` associated type (see [math crate](../math) for available field options).
 2. Define a set of public inputs which are required for your computation via the `PublicInputs` associated type.
 3. Implement `Air::new()` function. As a part of this function you should create a `AirContext` struct which takes degrees for all transition constraints as one of the constructor parameters.
 4. Implement `context()` method which should return a reference to the `AirContext` struct created in `Air::new()` function.

--- a/air/src/air/mod.rs
+++ b/air/src/air/mod.rs
@@ -146,7 +146,7 @@ pub trait Air: Send + Sync {
     /// Base field for the computation described by this AIR. STARK protocol for this computation
     /// may be executed in the base field, or in an extension of the base fields as specified
     /// by [ProofOptions] struct.
-    type BaseElement: ExtensibleField<2> + ExtensibleField<3>;
+    type BaseField: StarkField + ExtensibleField<2> + ExtensibleField<3>;
 
     /// A type defining shape of public inputs for the computation described by this protocol.
     /// This could be any type as long as it can be serialized into a sequence of bytes.
@@ -166,7 +166,7 @@ pub trait Air: Send + Sync {
     fn new(trace_info: TraceInfo, pub_inputs: Self::PublicInputs, options: ProofOptions) -> Self;
 
     /// Returns context for this instance of the computation.
-    fn context(&self) -> &AirContext<Self::BaseElement>;
+    fn context(&self) -> &AirContext<Self::BaseField>;
 
     /// Evaluates transition constraints over the specified evaluation frame.
     ///
@@ -174,7 +174,7 @@ pub trait Air: Send + Sync {
     /// the order of transition constraint degree descriptors used to instantiate [AirContext]
     /// for this AIR. Thus, the length of the `result` slice will equal to the number of
     /// transition constraints defined for this computation.
-    fn evaluate_transition<E: FieldElement<BaseField = Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement<BaseField = Self::BaseField>>(
         &self,
         frame: &EvaluationFrame<E>,
         periodic_values: &[E],
@@ -182,7 +182,7 @@ pub trait Air: Send + Sync {
     );
 
     /// Returns a set of assertions against a concrete execution trace of this computation.
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>>;
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>>;
 
     // PROVIDED METHODS
     // --------------------------------------------------------------------------------------------
@@ -196,7 +196,7 @@ pub trait Air: Send + Sync {
     /// The default implementation of this method returns an empty vector. For computations which
     /// rely on periodic columns, this method should be overridden in the specialized
     /// implementation. Number of values for each periodic column must be a power of two.
-    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseElement>> {
+    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseField>> {
         Vec::new()
     }
 
@@ -204,7 +204,7 @@ pub trait Air: Send + Sync {
     ///
     /// These polynomials are interpolated from the values returned from the
     /// [get_periodic_column_values()](Air::get_periodic_column_values) method.
-    fn get_periodic_column_polys(&self) -> Vec<Vec<Self::BaseElement>> {
+    fn get_periodic_column_polys(&self) -> Vec<Vec<Self::BaseField>> {
         // cache inverse twiddles for each cycle length so that we don't have to re-build them
         // for columns with identical cycle lengths
         let mut twiddle_map = BTreeMap::new();
@@ -233,7 +233,7 @@ pub trait Air: Send + Sync {
                 // get twiddles for interpolation and interpolate values into a polynomial
                 let inv_twiddles = twiddle_map
                     .entry(cycle_length)
-                    .or_insert_with(|| fft::get_inv_twiddles::<Self::BaseElement>(cycle_length));
+                    .or_insert_with(|| fft::get_inv_twiddles::<Self::BaseField>(cycle_length));
                 fft::interpolate_poly(&mut column, inv_twiddles);
                 column
             })
@@ -245,7 +245,7 @@ pub trait Air: Send + Sync {
     /// This function also assigns coefficients to each constraint. These coefficients will be
     /// used to compute a random linear combination of transition constraints evaluations during
     /// constraint merging performed by [TransitionConstraintGroup::merge_evaluations()] function.
-    fn get_transition_constraints<E: FieldElement<BaseField = Self::BaseElement>>(
+    fn get_transition_constraints<E: FieldElement<BaseField = Self::BaseField>>(
         &self,
         coefficients: &[(E, E)],
     ) -> Vec<TransitionConstraintGroup<E>> {
@@ -281,10 +281,10 @@ pub trait Air: Send + Sync {
     /// This function also assign coefficients to each constraint, and group the constraints by
     /// denominator. The coefficients will be used to compute random linear combination of boundary
     /// constraints during constraint merging.
-    fn get_boundary_constraints<E: FieldElement<BaseField = Self::BaseElement>>(
+    fn get_boundary_constraints<E: FieldElement<BaseField = Self::BaseField>>(
         &self,
         coefficients: &[(E, E)],
-    ) -> Vec<BoundaryConstraintGroup<Self::BaseElement, E>> {
+    ) -> Vec<BoundaryConstraintGroup<Self::BaseField, E>> {
         // compute inverse of the trace domain generator; this will be used for offset
         // computations when creating sequence constraints
         let inv_g = self.trace_domain_generator().inv();
@@ -371,7 +371,7 @@ pub trait Air: Send + Sync {
     /// by this AIR.
     ///
     /// The generator is the $n$th root of unity where $n$ is the length of the execution trace.
-    fn trace_domain_generator(&self) -> Self::BaseElement {
+    fn trace_domain_generator(&self) -> Self::BaseField {
         self.context().trace_domain_generator
     }
 
@@ -421,13 +421,13 @@ pub trait Air: Send + Sync {
     ///
     /// The generator is the $n$th root of unity where $n$ is the size of the low-degree extension
     /// domain.
-    fn lde_domain_generator(&self) -> Self::BaseElement {
+    fn lde_domain_generator(&self) -> Self::BaseField {
         self.context().lde_domain_generator
     }
 
     /// Returns the offset by which the domain for low-degree extension is shifted in relation
     /// to the execution trace domain.
-    fn domain_offset(&self) -> Self::BaseElement {
+    fn domain_offset(&self) -> Self::BaseField {
         self.context().options.domain_offset()
     }
 
@@ -460,7 +460,7 @@ pub trait Air: Send + Sync {
     ///
     /// This divisor specifies that transition constraints must hold on all steps of the
     /// execution trace except for the last one.
-    fn transition_constraint_divisor(&self) -> ConstraintDivisor<Self::BaseElement> {
+    fn transition_constraint_divisor(&self) -> ConstraintDivisor<Self::BaseField> {
         ConstraintDivisor::from_transition(self.trace_length())
     }
 
@@ -471,10 +471,10 @@ pub trait Air: Send + Sync {
     /// composition polynomial.
     fn get_constraint_composition_coefficients<E, H>(
         &self,
-        public_coin: &mut RandomCoin<Self::BaseElement, H>,
+        public_coin: &mut RandomCoin<Self::BaseField, H>,
     ) -> Result<ConstraintCompositionCoefficients<E>, RandomCoinError>
     where
-        E: FieldElement<BaseField = Self::BaseElement>,
+        E: FieldElement<BaseField = Self::BaseField>,
         H: Hasher,
     {
         let mut t_coefficients = Vec::new();
@@ -499,10 +499,10 @@ pub trait Air: Send + Sync {
     /// composition polynomial.
     fn get_deep_composition_coefficients<E, H>(
         &self,
-        public_coin: &mut RandomCoin<Self::BaseElement, H>,
+        public_coin: &mut RandomCoin<Self::BaseField, H>,
     ) -> Result<DeepCompositionCoefficients<E>, RandomCoinError>
     where
-        E: FieldElement<BaseField = Self::BaseElement>,
+        E: FieldElement<BaseField = Self::BaseField>,
         H: Hasher,
     {
         let mut t_coefficients = Vec::new();

--- a/air/src/air/mod.rs
+++ b/air/src/air/mod.rs
@@ -47,7 +47,7 @@ const MIN_CYCLE_LENGTH: usize = 2;
 /// To describe AIR for a given computation, you'll need to implement the `Air` trait which
 /// involves the following:
 ///
-/// 1. Define base field for your computation via the [Air::BaseElement] associated type (see
+/// 1. Define base field for your computation via the [Air::BaseField] associated type (see
 ///    [math::fields] for available field options).
 /// 2. Define a set of public inputs which are required for your computation via the
 ///    [Air::PublicInputs] associated type.

--- a/air/src/air/tests.rs
+++ b/air/src/air/tests.rs
@@ -344,7 +344,7 @@ impl MockAir {
 }
 
 impl Air for MockAir {
-    type BaseElement = BaseElement;
+    type BaseField = BaseElement;
     type PublicInputs = ();
 
     fn new(trace_info: TraceInfo, _pub_inputs: (), _options: ProofOptions) -> Self {
@@ -356,19 +356,19 @@ impl Air for MockAir {
         }
     }
 
-    fn context(&self) -> &AirContext<Self::BaseElement> {
+    fn context(&self) -> &AirContext<Self::BaseField> {
         &self.context
     }
 
-    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseElement>> {
+    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseField>> {
         self.periodic_columns.clone()
     }
 
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
         self.assertions.clone()
     }
 
-    fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
         _frame: &EvaluationFrame<E>,
         _periodic_values: &[E],

--- a/examples/src/fibonacci/fib2/air.rs
+++ b/examples/src/fibonacci/fib2/air.rs
@@ -18,12 +18,12 @@ pub struct FibAir {
 }
 
 impl Air for FibAir {
-    type BaseElement = BaseElement;
+    type BaseField = BaseElement;
     type PublicInputs = BaseElement;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
-    fn new(trace_info: TraceInfo, pub_inputs: Self::BaseElement, options: ProofOptions) -> Self {
+    fn new(trace_info: TraceInfo, pub_inputs: Self::BaseField, options: ProofOptions) -> Self {
         let degrees = vec![
             TransitionConstraintDegree::new(1),
             TransitionConstraintDegree::new(1),
@@ -35,11 +35,11 @@ impl Air for FibAir {
         }
     }
 
-    fn context(&self) -> &AirContext<Self::BaseElement> {
+    fn context(&self) -> &AirContext<Self::BaseField> {
         &self.context
     }
 
-    fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
         frame: &EvaluationFrame<E>,
         _periodic_values: &[E],
@@ -58,13 +58,13 @@ impl Air for FibAir {
         result[1] = are_equal(next[1], current[1] + next[0]);
     }
 
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
         // a valid Fibonacci sequence should start with two ones and terminate with
         // the expected result
         let last_step = self.trace_length() - 1;
         vec![
-            Assertion::single(0, 0, Self::BaseElement::ONE),
-            Assertion::single(1, 0, Self::BaseElement::ONE),
+            Assertion::single(0, 0, Self::BaseField::ONE),
+            Assertion::single(1, 0, Self::BaseField::ONE),
             Assertion::single(1, last_step, self.result),
         ]
     }

--- a/examples/src/fibonacci/fib2/air.rs
+++ b/examples/src/fibonacci/fib2/air.rs
@@ -3,17 +3,14 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use super::{BaseElement, FieldElement, ProofOptions, TRACE_WIDTH};
 use crate::utils::are_equal;
 use winterfell::{
-    math::{fields::f128::BaseElement, FieldElement},
-    Air, AirContext, Assertion, EvaluationFrame, ExecutionTrace, ProofOptions, TraceInfo,
-    TransitionConstraintDegree,
+    Air, AirContext, Assertion, EvaluationFrame, TraceInfo, TransitionConstraintDegree,
 };
 
 // FIBONACCI AIR
 // ================================================================================================
-
-const TRACE_WIDTH: usize = 2;
 
 pub struct FibAir {
     context: AirContext<BaseElement>,
@@ -71,27 +68,4 @@ impl Air for FibAir {
             Assertion::single(1, last_step, self.result),
         ]
     }
-}
-
-// FIBONACCI TRACE BUILDER
-// ================================================================================================
-pub fn build_trace(sequence_length: usize) -> ExecutionTrace<BaseElement> {
-    assert!(
-        sequence_length.is_power_of_two(),
-        "sequence length must be a power of 2"
-    );
-
-    let mut trace = ExecutionTrace::new(TRACE_WIDTH, sequence_length / 2);
-    trace.fill(
-        |state| {
-            state[0] = BaseElement::ONE;
-            state[1] = BaseElement::ONE;
-        },
-        |_, state| {
-            state[0] += state[1];
-            state[1] += state[0];
-        },
-    );
-
-    trace
 }

--- a/examples/src/fibonacci/fib2/mod.rs
+++ b/examples/src/fibonacci/fib2/mod.rs
@@ -94,7 +94,7 @@ impl Example for FibExample {
         );
 
         // generate the proof
-        prover.prove(trace, self.result).unwrap()
+        prover.prove(trace).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/fibonacci/fib2/mod.rs
+++ b/examples/src/fibonacci/fib2/mod.rs
@@ -9,7 +9,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
+    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
 };
 
 mod air;

--- a/examples/src/fibonacci/fib2/mod.rs
+++ b/examples/src/fibonacci/fib2/mod.rs
@@ -9,14 +9,22 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ProofOptions, StarkProof, VerifierError,
+    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
 };
 
 mod air;
-use air::{build_trace, FibAir};
+use air::FibAir;
+
+mod prover;
+use prover::FibProver;
 
 #[cfg(test)]
 mod tests;
+
+// CONSTANTS
+// ================================================================================================
+
+const TRACE_WIDTH: usize = 2;
 
 // FIBONACCI EXAMPLE
 // ================================================================================================
@@ -69,9 +77,12 @@ impl Example for FibExample {
             self.sequence_length
         );
 
+        // create a prover
+        let prover = FibProver::new(self.options.clone());
+
         // generate execution trace
         let now = Instant::now();
-        let trace = build_trace(self.sequence_length);
+        let trace = prover.build_trace(self.sequence_length);
 
         let trace_width = trace.width();
         let trace_length = trace.length();
@@ -83,7 +94,7 @@ impl Example for FibExample {
         );
 
         // generate the proof
-        winterfell::prove::<FibAir>(trace, self.result, self.options.clone()).unwrap()
+        prover.prove(trace, self.result).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/fibonacci/fib2/mod.rs
+++ b/examples/src/fibonacci/fib2/mod.rs
@@ -9,7 +9,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
+    ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
 mod air;

--- a/examples/src/fibonacci/fib2/prover.rs
+++ b/examples/src/fibonacci/fib2/prover.rs
@@ -1,0 +1,46 @@
+use super::{BaseElement, ExecutionTrace, FibAir, FieldElement, ProofOptions, Prover, TRACE_WIDTH};
+
+// FIBONACCI PROVER
+// ================================================================================================
+
+pub struct FibProver {
+    options: ProofOptions,
+}
+
+impl FibProver {
+    pub fn new(options: ProofOptions) -> Self {
+        Self { options }
+    }
+
+    /// Builds an execution trace for computing a Fibonacci sequence of the specified length such
+    /// that each row advances the sequence by 2 terms.
+    pub fn build_trace(&self, sequence_length: usize) -> ExecutionTrace<BaseElement> {
+        assert!(
+            sequence_length.is_power_of_two(),
+            "sequence length must be a power of 2"
+        );
+
+        let mut trace = ExecutionTrace::new(TRACE_WIDTH, sequence_length / 2);
+        trace.fill(
+            |state| {
+                state[0] = BaseElement::ONE;
+                state[1] = BaseElement::ONE;
+            },
+            |_, state| {
+                state[0] += state[1];
+                state[1] += state[0];
+            },
+        );
+
+        trace
+    }
+}
+
+impl Prover for FibProver {
+    type BaseField = BaseElement;
+    type AIR = FibAir;
+
+    fn options(&self) -> &ProofOptions {
+        &self.options
+    }
+}

--- a/examples/src/fibonacci/fib2/prover.rs
+++ b/examples/src/fibonacci/fib2/prover.rs
@@ -3,7 +3,9 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{BaseElement, FibAir, FieldElement, ProofOptions, Prover, TraceTable, TRACE_WIDTH};
+use super::{
+    BaseElement, FibAir, FieldElement, ProofOptions, Prover, Trace, TraceTable, TRACE_WIDTH,
+};
 
 // FIBONACCI PROVER
 // ================================================================================================
@@ -45,6 +47,11 @@ impl Prover for FibProver {
     type BaseField = BaseElement;
     type Air = FibAir;
     type Trace = TraceTable<BaseElement>;
+
+    fn get_pub_inputs(&self, trace: &Self::Trace) -> BaseElement {
+        let last_step = trace.length() - 1;
+        trace.get(1, last_step)
+    }
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/fibonacci/fib2/prover.rs
+++ b/examples/src/fibonacci/fib2/prover.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{BaseElement, ExecutionTrace, FibAir, FieldElement, ProofOptions, Prover, TRACE_WIDTH};
+use super::{BaseElement, FibAir, FieldElement, ProofOptions, Prover, TraceTable, TRACE_WIDTH};
 
 // FIBONACCI PROVER
 // ================================================================================================
@@ -19,13 +19,13 @@ impl FibProver {
 
     /// Builds an execution trace for computing a Fibonacci sequence of the specified length such
     /// that each row advances the sequence by 2 terms.
-    pub fn build_trace(&self, sequence_length: usize) -> ExecutionTrace<BaseElement> {
+    pub fn build_trace(&self, sequence_length: usize) -> TraceTable<BaseElement> {
         assert!(
             sequence_length.is_power_of_two(),
             "sequence length must be a power of 2"
         );
 
-        let mut trace = ExecutionTrace::new(TRACE_WIDTH, sequence_length / 2);
+        let mut trace = TraceTable::new(TRACE_WIDTH, sequence_length / 2);
         trace.fill(
             |state| {
                 state[0] = BaseElement::ONE;
@@ -44,7 +44,7 @@ impl FibProver {
 impl Prover for FibProver {
     type BaseField = BaseElement;
     type Air = FibAir;
-    type Trace = ExecutionTrace<BaseElement>;
+    type Trace = TraceTable<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/fibonacci/fib2/prover.rs
+++ b/examples/src/fibonacci/fib2/prover.rs
@@ -1,3 +1,8 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 use super::{BaseElement, ExecutionTrace, FibAir, FieldElement, ProofOptions, Prover, TRACE_WIDTH};
 
 // FIBONACCI PROVER
@@ -38,7 +43,8 @@ impl FibProver {
 
 impl Prover for FibProver {
     type BaseField = BaseElement;
-    type AIR = FibAir;
+    type Air = FibAir;
+    type Trace = ExecutionTrace<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/fibonacci/fib8/air.rs
+++ b/examples/src/fibonacci/fib8/air.rs
@@ -19,12 +19,12 @@ pub struct Fib8Air {
 }
 
 impl Air for Fib8Air {
-    type BaseElement = BaseElement;
+    type BaseField = BaseElement;
     type PublicInputs = BaseElement;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
-    fn new(trace_info: TraceInfo, pub_inputs: Self::BaseElement, options: ProofOptions) -> Self {
+    fn new(trace_info: TraceInfo, pub_inputs: Self::BaseField, options: ProofOptions) -> Self {
         let degrees = vec![
             TransitionConstraintDegree::new(1),
             TransitionConstraintDegree::new(1),
@@ -36,11 +36,11 @@ impl Air for Fib8Air {
         }
     }
 
-    fn context(&self) -> &AirContext<Self::BaseElement> {
+    fn context(&self) -> &AirContext<Self::BaseField> {
         &self.context
     }
 
-    fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
         frame: &EvaluationFrame<E>,
         _periodic_values: &[E],
@@ -66,7 +66,7 @@ impl Air for Fib8Air {
         result[1] = are_equal(next[1], n7);
     }
 
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
         // assert that the trace starts with 7th and 8th terms of Fibonacci sequence (the first
         // 6 terms are not recorded in the trace), and ends with the expected result
         let last_step = self.trace_length() - 1;

--- a/examples/src/fibonacci/fib8/air.rs
+++ b/examples/src/fibonacci/fib8/air.rs
@@ -3,17 +3,15 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use super::{BaseElement, FieldElement, TRACE_WIDTH};
 use crate::utils::are_equal;
 use winterfell::{
-    math::{fields::f128::BaseElement, FieldElement},
-    Air, AirContext, Assertion, EvaluationFrame, ExecutionTrace, ProofOptions, TraceInfo,
+    Air, AirContext, Assertion, EvaluationFrame, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
 
 // FIBONACCI AIR
 // ================================================================================================
-
-const TRACE_WIDTH: usize = 2;
 
 pub struct Fib8Air {
     context: AirContext<BaseElement>,
@@ -78,43 +76,4 @@ impl Air for Fib8Air {
             Assertion::single(1, last_step, self.result),
         ]
     }
-}
-
-// FIBONACCI TRACE BUILDER
-// ================================================================================================
-
-pub fn build_trace(length: usize) -> ExecutionTrace<BaseElement> {
-    assert!(
-        length.is_power_of_two(),
-        "sequence length must be a power of 2"
-    );
-
-    // initialize the trace with 7th and 8th terms of Fibonacci sequence (skipping the first 6)
-    let n0 = BaseElement::ONE;
-    let n1 = BaseElement::ONE;
-    let n2 = n0 + n1;
-    let n3 = n1 + n2;
-    let n4 = n2 + n3;
-    let n5 = n3 + n4;
-    let n6 = n4 + n5;
-    let n7 = n5 + n6;
-
-    let mut reg0 = vec![n6];
-    let mut reg1 = vec![n7];
-
-    for i in 0..(length / 8 - 1) {
-        let n0 = reg0[i] + reg1[i];
-        let n1 = reg1[i] + n0;
-        let n2 = n0 + n1;
-        let n3 = n1 + n2;
-        let n4 = n2 + n3;
-        let n5 = n3 + n4;
-        let n6 = n4 + n5;
-        let n7 = n5 + n6;
-
-        reg0.push(n6);
-        reg1.push(n7);
-    }
-
-    ExecutionTrace::init(vec![reg0, reg1])
 }

--- a/examples/src/fibonacci/fib8/mod.rs
+++ b/examples/src/fibonacci/fib8/mod.rs
@@ -93,7 +93,7 @@ impl Example for Fib8Example {
         );
 
         // generate the proof
-        prover.prove(trace, self.result).unwrap()
+        prover.prove(trace).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/fibonacci/fib8/mod.rs
+++ b/examples/src/fibonacci/fib8/mod.rs
@@ -9,7 +9,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
+    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
 };
 
 mod air;

--- a/examples/src/fibonacci/fib8/mod.rs
+++ b/examples/src/fibonacci/fib8/mod.rs
@@ -9,7 +9,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
+    ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
 mod air;

--- a/examples/src/fibonacci/fib8/mod.rs
+++ b/examples/src/fibonacci/fib8/mod.rs
@@ -9,14 +9,22 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ProofOptions, StarkProof, VerifierError,
+    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
 };
 
 mod air;
-use air::{build_trace, Fib8Air};
+use air::Fib8Air;
+
+mod prover;
+use prover::Fib8Prover;
 
 #[cfg(test)]
 mod tests;
+
+// CONSTANTS
+// ================================================================================================
+
+const TRACE_WIDTH: usize = 2;
 
 // FIBONACCI EXAMPLE
 // ================================================================================================
@@ -69,9 +77,12 @@ impl Example for Fib8Example {
             self.sequence_length
         );
 
+        // create a prover
+        let prover = Fib8Prover::new(self.options.clone());
+
         // generate execution trace
         let now = Instant::now();
-        let trace = build_trace(self.sequence_length);
+        let trace = prover.build_trace(self.sequence_length);
         let trace_width = trace.width();
         let trace_length = trace.length();
         debug!(
@@ -82,7 +93,7 @@ impl Example for Fib8Example {
         );
 
         // generate the proof
-        winterfell::prove::<Fib8Air>(trace, self.result, self.options.clone()).unwrap()
+        prover.prove(trace, self.result).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/fibonacci/fib8/prover.rs
+++ b/examples/src/fibonacci/fib8/prover.rs
@@ -1,3 +1,8 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 use super::{BaseElement, ExecutionTrace, Fib8Air, FieldElement, ProofOptions, Prover};
 
 // FIBONACCI PROVER
@@ -53,7 +58,8 @@ impl Fib8Prover {
 
 impl Prover for Fib8Prover {
     type BaseField = BaseElement;
-    type AIR = Fib8Air;
+    type Air = Fib8Air;
+    type Trace = ExecutionTrace<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/fibonacci/fib8/prover.rs
+++ b/examples/src/fibonacci/fib8/prover.rs
@@ -1,0 +1,61 @@
+use super::{BaseElement, ExecutionTrace, Fib8Air, FieldElement, ProofOptions, Prover};
+
+// FIBONACCI PROVER
+// ================================================================================================
+
+pub struct Fib8Prover {
+    options: ProofOptions,
+}
+
+impl Fib8Prover {
+    pub fn new(options: ProofOptions) -> Self {
+        Self { options }
+    }
+
+    /// Builds an execution trace for computing a Fibonacci sequence of the specified length such
+    /// that each row advances the sequence by 8 terms.
+    pub fn build_trace(&self, length: usize) -> ExecutionTrace<BaseElement> {
+        assert!(
+            length.is_power_of_two(),
+            "sequence length must be a power of 2"
+        );
+
+        // initialize the trace with 7th and 8th terms of Fibonacci sequence (skipping the first 6)
+        let n0 = BaseElement::ONE;
+        let n1 = BaseElement::ONE;
+        let n2 = n0 + n1;
+        let n3 = n1 + n2;
+        let n4 = n2 + n3;
+        let n5 = n3 + n4;
+        let n6 = n4 + n5;
+        let n7 = n5 + n6;
+
+        let mut reg0 = vec![n6];
+        let mut reg1 = vec![n7];
+
+        for i in 0..(length / 8 - 1) {
+            let n0 = reg0[i] + reg1[i];
+            let n1 = reg1[i] + n0;
+            let n2 = n0 + n1;
+            let n3 = n1 + n2;
+            let n4 = n2 + n3;
+            let n5 = n3 + n4;
+            let n6 = n4 + n5;
+            let n7 = n5 + n6;
+
+            reg0.push(n6);
+            reg1.push(n7);
+        }
+
+        ExecutionTrace::init(vec![reg0, reg1])
+    }
+}
+
+impl Prover for Fib8Prover {
+    type BaseField = BaseElement;
+    type AIR = Fib8Air;
+
+    fn options(&self) -> &ProofOptions {
+        &self.options
+    }
+}

--- a/examples/src/fibonacci/fib8/prover.rs
+++ b/examples/src/fibonacci/fib8/prover.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{BaseElement, Fib8Air, FieldElement, ProofOptions, Prover, TraceTable};
+use super::{BaseElement, Fib8Air, FieldElement, ProofOptions, Prover, Trace, TraceTable};
 
 // FIBONACCI PROVER
 // ================================================================================================
@@ -60,6 +60,11 @@ impl Prover for Fib8Prover {
     type BaseField = BaseElement;
     type Air = Fib8Air;
     type Trace = TraceTable<BaseElement>;
+
+    fn get_pub_inputs(&self, trace: &Self::Trace) -> BaseElement {
+        let last_step = trace.length() - 1;
+        trace.get(1, last_step)
+    }
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/fibonacci/fib8/prover.rs
+++ b/examples/src/fibonacci/fib8/prover.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{BaseElement, ExecutionTrace, Fib8Air, FieldElement, ProofOptions, Prover};
+use super::{BaseElement, Fib8Air, FieldElement, ProofOptions, Prover, TraceTable};
 
 // FIBONACCI PROVER
 // ================================================================================================
@@ -19,7 +19,7 @@ impl Fib8Prover {
 
     /// Builds an execution trace for computing a Fibonacci sequence of the specified length such
     /// that each row advances the sequence by 8 terms.
-    pub fn build_trace(&self, length: usize) -> ExecutionTrace<BaseElement> {
+    pub fn build_trace(&self, length: usize) -> TraceTable<BaseElement> {
         assert!(
             length.is_power_of_two(),
             "sequence length must be a power of 2"
@@ -52,14 +52,14 @@ impl Fib8Prover {
             reg1.push(n7);
         }
 
-        ExecutionTrace::init(vec![reg0, reg1])
+        TraceTable::init(vec![reg0, reg1])
     }
 }
 
 impl Prover for Fib8Prover {
     type BaseField = BaseElement;
     type Air = Fib8Air;
-    type Trace = ExecutionTrace<BaseElement>;
+    type Trace = TraceTable<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/fibonacci/mulfib2/air.rs
+++ b/examples/src/fibonacci/mulfib2/air.rs
@@ -21,12 +21,12 @@ pub struct MulFib2Air {
 }
 
 impl Air for MulFib2Air {
-    type BaseElement = BaseElement;
+    type BaseField = BaseElement;
     type PublicInputs = BaseElement;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
-    fn new(trace_info: TraceInfo, pub_inputs: Self::BaseElement, options: ProofOptions) -> Self {
+    fn new(trace_info: TraceInfo, pub_inputs: Self::BaseField, options: ProofOptions) -> Self {
         let degrees = vec![
             TransitionConstraintDegree::new(2),
             TransitionConstraintDegree::new(2),
@@ -38,11 +38,11 @@ impl Air for MulFib2Air {
         }
     }
 
-    fn context(&self) -> &AirContext<Self::BaseElement> {
+    fn context(&self) -> &AirContext<Self::BaseField> {
         &self.context
     }
 
-    fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
         frame: &EvaluationFrame<E>,
         _periodic_values: &[E],
@@ -61,13 +61,13 @@ impl Air for MulFib2Air {
         result[1] = are_equal(next[1], current[1] * next[0]);
     }
 
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
         // a valid multiplicative Fibonacci sequence should start with 1, 2 and terminate
         // with the expected result
         let last_step = self.trace_length() - 1;
         vec![
-            Assertion::single(0, 0, Self::BaseElement::new(1)),
-            Assertion::single(1, 0, Self::BaseElement::new(2)),
+            Assertion::single(0, 0, Self::BaseField::new(1)),
+            Assertion::single(1, 0, Self::BaseField::new(2)),
             Assertion::single(0, last_step, self.result),
         ]
     }

--- a/examples/src/fibonacci/mulfib2/air.rs
+++ b/examples/src/fibonacci/mulfib2/air.rs
@@ -6,7 +6,7 @@
 use crate::utils::are_equal;
 use winterfell::{
     math::{fields::f128::BaseElement, FieldElement},
-    Air, AirContext, Assertion, EvaluationFrame, ExecutionTrace, ProofOptions, TraceInfo,
+    Air, AirContext, Assertion, EvaluationFrame, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
 
@@ -71,24 +71,4 @@ impl Air for MulFib2Air {
             Assertion::single(0, last_step, self.result),
         ]
     }
-}
-
-// FIBONACCI TRACE BUILDER
-// ================================================================================================
-
-pub fn build_trace(length: usize) -> ExecutionTrace<BaseElement> {
-    assert!(
-        length.is_power_of_two(),
-        "sequence length must be a power of 2"
-    );
-
-    let mut reg0 = vec![BaseElement::new(1)];
-    let mut reg1 = vec![BaseElement::new(2)];
-
-    for i in 0..(length / 2 - 1) {
-        reg0.push(reg0[i] * reg1[i]);
-        reg1.push(reg1[i] * reg0[i + 1]);
-    }
-
-    ExecutionTrace::init(vec![reg0, reg1])
 }

--- a/examples/src/fibonacci/mulfib2/mod.rs
+++ b/examples/src/fibonacci/mulfib2/mod.rs
@@ -9,7 +9,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
+    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
 };
 
 mod air;

--- a/examples/src/fibonacci/mulfib2/mod.rs
+++ b/examples/src/fibonacci/mulfib2/mod.rs
@@ -88,7 +88,7 @@ impl Example for MulFib2Example {
         );
 
         // generate the proof
-        prover.prove(trace, self.result).unwrap()
+        prover.prove(trace).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/fibonacci/mulfib2/mod.rs
+++ b/examples/src/fibonacci/mulfib2/mod.rs
@@ -9,7 +9,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
+    ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
 mod air;

--- a/examples/src/fibonacci/mulfib2/mod.rs
+++ b/examples/src/fibonacci/mulfib2/mod.rs
@@ -9,11 +9,14 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ProofOptions, StarkProof, VerifierError,
+    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
 };
 
 mod air;
-use air::{build_trace, MulFib2Air};
+use air::MulFib2Air;
+
+mod prover;
+use prover::MulFib2Prover;
 
 #[cfg(test)]
 mod tests;
@@ -69,9 +72,12 @@ impl Example for MulFib2Example {
             sequence_length
         );
 
+        // create a prover
+        let prover = MulFib2Prover::new(self.options.clone());
+
         // generate execution trace
         let now = Instant::now();
-        let trace = build_trace(sequence_length);
+        let trace = prover.build_trace(sequence_length);
         let trace_width = trace.width();
         let trace_length = trace.length();
         debug!(
@@ -82,7 +88,7 @@ impl Example for MulFib2Example {
         );
 
         // generate the proof
-        winterfell::prove::<MulFib2Air>(trace, self.result, self.options.clone()).unwrap()
+        prover.prove(trace, self.result).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/fibonacci/mulfib2/prover.rs
+++ b/examples/src/fibonacci/mulfib2/prover.rs
@@ -1,0 +1,42 @@
+use super::{BaseElement, ExecutionTrace, MulFib2Air, ProofOptions, Prover};
+
+// FIBONACCI PROVER
+// ================================================================================================
+
+pub struct MulFib2Prover {
+    options: ProofOptions,
+}
+
+impl MulFib2Prover {
+    pub fn new(options: ProofOptions) -> Self {
+        Self { options }
+    }
+
+    /// Builds an execution trace for computing a multiplicative version of a Fibonacci sequence of
+    /// the specified length such that each row advances the sequence by 2 terms.
+    pub fn build_trace(&self, length: usize) -> ExecutionTrace<BaseElement> {
+        assert!(
+            length.is_power_of_two(),
+            "sequence length must be a power of 2"
+        );
+
+        let mut reg0 = vec![BaseElement::new(1)];
+        let mut reg1 = vec![BaseElement::new(2)];
+
+        for i in 0..(length / 2 - 1) {
+            reg0.push(reg0[i] * reg1[i]);
+            reg1.push(reg1[i] * reg0[i + 1]);
+        }
+
+        ExecutionTrace::init(vec![reg0, reg1])
+    }
+}
+
+impl Prover for MulFib2Prover {
+    type BaseField = BaseElement;
+    type AIR = MulFib2Air;
+
+    fn options(&self) -> &ProofOptions {
+        &self.options
+    }
+}

--- a/examples/src/fibonacci/mulfib2/prover.rs
+++ b/examples/src/fibonacci/mulfib2/prover.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{BaseElement, MulFib2Air, ProofOptions, Prover, TraceTable};
+use super::{BaseElement, MulFib2Air, ProofOptions, Prover, Trace, TraceTable};
 
 // FIBONACCI PROVER
 // ================================================================================================
@@ -41,6 +41,11 @@ impl Prover for MulFib2Prover {
     type BaseField = BaseElement;
     type Air = MulFib2Air;
     type Trace = TraceTable<BaseElement>;
+
+    fn get_pub_inputs(&self, trace: &Self::Trace) -> BaseElement {
+        let last_step = trace.length() - 1;
+        trace.get(0, last_step)
+    }
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/fibonacci/mulfib2/prover.rs
+++ b/examples/src/fibonacci/mulfib2/prover.rs
@@ -1,3 +1,8 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 use super::{BaseElement, ExecutionTrace, MulFib2Air, ProofOptions, Prover};
 
 // FIBONACCI PROVER
@@ -34,7 +39,8 @@ impl MulFib2Prover {
 
 impl Prover for MulFib2Prover {
     type BaseField = BaseElement;
-    type AIR = MulFib2Air;
+    type Air = MulFib2Air;
+    type Trace = ExecutionTrace<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/fibonacci/mulfib2/prover.rs
+++ b/examples/src/fibonacci/mulfib2/prover.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{BaseElement, ExecutionTrace, MulFib2Air, ProofOptions, Prover};
+use super::{BaseElement, MulFib2Air, ProofOptions, Prover, TraceTable};
 
 // FIBONACCI PROVER
 // ================================================================================================
@@ -19,7 +19,7 @@ impl MulFib2Prover {
 
     /// Builds an execution trace for computing a multiplicative version of a Fibonacci sequence of
     /// the specified length such that each row advances the sequence by 2 terms.
-    pub fn build_trace(&self, length: usize) -> ExecutionTrace<BaseElement> {
+    pub fn build_trace(&self, length: usize) -> TraceTable<BaseElement> {
         assert!(
             length.is_power_of_two(),
             "sequence length must be a power of 2"
@@ -33,14 +33,14 @@ impl MulFib2Prover {
             reg1.push(reg1[i] * reg0[i + 1]);
         }
 
-        ExecutionTrace::init(vec![reg0, reg1])
+        TraceTable::init(vec![reg0, reg1])
     }
 }
 
 impl Prover for MulFib2Prover {
     type BaseField = BaseElement;
     type Air = MulFib2Air;
-    type Trace = ExecutionTrace<BaseElement>;
+    type Trace = TraceTable<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/fibonacci/mulfib8/air.rs
+++ b/examples/src/fibonacci/mulfib8/air.rs
@@ -21,12 +21,12 @@ pub struct MulFib8Air {
 }
 
 impl Air for MulFib8Air {
-    type BaseElement = BaseElement;
+    type BaseField = BaseElement;
     type PublicInputs = BaseElement;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
-    fn new(trace_info: TraceInfo, pub_inputs: Self::BaseElement, options: ProofOptions) -> Self {
+    fn new(trace_info: TraceInfo, pub_inputs: Self::BaseField, options: ProofOptions) -> Self {
         let degrees = vec![
             TransitionConstraintDegree::new(2),
             TransitionConstraintDegree::new(2),
@@ -44,11 +44,11 @@ impl Air for MulFib8Air {
         }
     }
 
-    fn context(&self) -> &AirContext<Self::BaseElement> {
+    fn context(&self) -> &AirContext<Self::BaseField> {
         &self.context
     }
 
-    fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
         frame: &EvaluationFrame<E>,
         _periodic_values: &[E],
@@ -79,7 +79,7 @@ impl Air for MulFib8Air {
         result[7] = are_equal(next[7], next[5] * next[6]);
     }
 
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
         // a valid multiplicative Fibonacci sequence should start with 1, 2 and terminate
         // with the expected result
         let last_step = self.trace_length() - 1;

--- a/examples/src/fibonacci/mulfib8/air.rs
+++ b/examples/src/fibonacci/mulfib8/air.rs
@@ -6,7 +6,7 @@
 use crate::utils::are_equal;
 use winterfell::{
     math::{fields::f128::BaseElement, FieldElement},
-    Air, AirContext, Assertion, EvaluationFrame, ExecutionTrace, ProofOptions, TraceInfo,
+    Air, AirContext, Assertion, EvaluationFrame, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
 
@@ -89,36 +89,4 @@ impl Air for MulFib8Air {
             Assertion::single(6, last_step, self.result),
         ]
     }
-}
-
-// FIBONACCI TRACE BUILDER
-// ================================================================================================
-
-pub fn build_trace(length: usize) -> ExecutionTrace<BaseElement> {
-    assert!(
-        length.is_power_of_two(),
-        "sequence length must be a power of 2"
-    );
-
-    let mut reg0 = vec![BaseElement::new(1)];
-    let mut reg1 = vec![BaseElement::new(2)];
-    let mut reg2 = vec![reg0[0] * reg1[0]];
-    let mut reg3 = vec![reg1[0] * reg2[0]];
-    let mut reg4 = vec![reg2[0] * reg3[0]];
-    let mut reg5 = vec![reg3[0] * reg4[0]];
-    let mut reg6 = vec![reg4[0] * reg5[0]];
-    let mut reg7 = vec![reg5[0] * reg6[0]];
-
-    for i in 0..(length / 8 - 1) {
-        reg0.push(reg6[i] * reg7[i]);
-        reg1.push(reg7[i] * reg0[i + 1]);
-        reg2.push(reg0[i + 1] * reg1[i + 1]);
-        reg3.push(reg1[i + 1] * reg2[i + 1]);
-        reg4.push(reg2[i + 1] * reg3[i + 1]);
-        reg5.push(reg3[i + 1] * reg4[i + 1]);
-        reg6.push(reg4[i + 1] * reg5[i + 1]);
-        reg7.push(reg5[i + 1] * reg6[i + 1]);
-    }
-
-    ExecutionTrace::init(vec![reg0, reg1, reg2, reg3, reg4, reg5, reg6, reg7])
 }

--- a/examples/src/fibonacci/mulfib8/mod.rs
+++ b/examples/src/fibonacci/mulfib8/mod.rs
@@ -89,7 +89,7 @@ impl Example for MulFib8Example {
         );
 
         // generate the proof
-        prover.prove(trace, self.result).unwrap()
+        prover.prove(trace).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/fibonacci/mulfib8/mod.rs
+++ b/examples/src/fibonacci/mulfib8/mod.rs
@@ -9,7 +9,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
+    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
 };
 
 mod air;

--- a/examples/src/fibonacci/mulfib8/mod.rs
+++ b/examples/src/fibonacci/mulfib8/mod.rs
@@ -9,7 +9,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
+    ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
 mod air;

--- a/examples/src/fibonacci/mulfib8/mod.rs
+++ b/examples/src/fibonacci/mulfib8/mod.rs
@@ -9,11 +9,14 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ProofOptions, StarkProof, VerifierError,
+    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
 };
 
 mod air;
-use air::{build_trace, MulFib8Air};
+use air::MulFib8Air;
+
+mod prover;
+use prover::MulFib8Prover;
 
 #[cfg(test)]
 mod tests;
@@ -70,9 +73,12 @@ impl Example for MulFib8Example {
             sequence_length
         );
 
+        // create a prover
+        let prover = MulFib8Prover::new(self.options.clone());
+
         // generate execution trace
         let now = Instant::now();
-        let trace = build_trace(sequence_length);
+        let trace = prover.build_trace(sequence_length);
         let trace_width = trace.width();
         let trace_length = trace.length();
         debug!(
@@ -83,7 +89,7 @@ impl Example for MulFib8Example {
         );
 
         // generate the proof
-        winterfell::prove::<MulFib8Air>(trace, self.result, self.options.clone()).unwrap()
+        prover.prove(trace, self.result).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/fibonacci/mulfib8/prover.rs
+++ b/examples/src/fibonacci/mulfib8/prover.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{BaseElement, ExecutionTrace, MulFib8Air, ProofOptions, Prover};
+use super::{BaseElement, MulFib8Air, ProofOptions, Prover, TraceTable};
 
 // FIBONACCI PROVER
 // ================================================================================================
@@ -19,7 +19,7 @@ impl MulFib8Prover {
 
     /// Builds an execution trace for computing a multiplicative version of a Fibonacci sequence of
     /// the specified length such that each row advances the sequence by 8 terms.
-    pub fn build_trace(&self, length: usize) -> ExecutionTrace<BaseElement> {
+    pub fn build_trace(&self, length: usize) -> TraceTable<BaseElement> {
         assert!(
             length.is_power_of_two(),
             "sequence length must be a power of 2"
@@ -45,14 +45,14 @@ impl MulFib8Prover {
             reg7.push(reg5[i + 1] * reg6[i + 1]);
         }
 
-        ExecutionTrace::init(vec![reg0, reg1, reg2, reg3, reg4, reg5, reg6, reg7])
+        TraceTable::init(vec![reg0, reg1, reg2, reg3, reg4, reg5, reg6, reg7])
     }
 }
 
 impl Prover for MulFib8Prover {
     type BaseField = BaseElement;
     type Air = MulFib8Air;
-    type Trace = ExecutionTrace<BaseElement>;
+    type Trace = TraceTable<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/fibonacci/mulfib8/prover.rs
+++ b/examples/src/fibonacci/mulfib8/prover.rs
@@ -1,0 +1,54 @@
+use super::{BaseElement, ExecutionTrace, MulFib8Air, ProofOptions, Prover};
+
+// FIBONACCI PROVER
+// ================================================================================================
+
+pub struct MulFib8Prover {
+    options: ProofOptions,
+}
+
+impl MulFib8Prover {
+    pub fn new(options: ProofOptions) -> Self {
+        Self { options }
+    }
+
+    /// Builds an execution trace for computing a multiplicative version of a Fibonacci sequence of
+    /// the specified length such that each row advances the sequence by 8 terms.
+    pub fn build_trace(&self, length: usize) -> ExecutionTrace<BaseElement> {
+        assert!(
+            length.is_power_of_two(),
+            "sequence length must be a power of 2"
+        );
+
+        let mut reg0 = vec![BaseElement::new(1)];
+        let mut reg1 = vec![BaseElement::new(2)];
+        let mut reg2 = vec![reg0[0] * reg1[0]];
+        let mut reg3 = vec![reg1[0] * reg2[0]];
+        let mut reg4 = vec![reg2[0] * reg3[0]];
+        let mut reg5 = vec![reg3[0] * reg4[0]];
+        let mut reg6 = vec![reg4[0] * reg5[0]];
+        let mut reg7 = vec![reg5[0] * reg6[0]];
+
+        for i in 0..(length / 8 - 1) {
+            reg0.push(reg6[i] * reg7[i]);
+            reg1.push(reg7[i] * reg0[i + 1]);
+            reg2.push(reg0[i + 1] * reg1[i + 1]);
+            reg3.push(reg1[i + 1] * reg2[i + 1]);
+            reg4.push(reg2[i + 1] * reg3[i + 1]);
+            reg5.push(reg3[i + 1] * reg4[i + 1]);
+            reg6.push(reg4[i + 1] * reg5[i + 1]);
+            reg7.push(reg5[i + 1] * reg6[i + 1]);
+        }
+
+        ExecutionTrace::init(vec![reg0, reg1, reg2, reg3, reg4, reg5, reg6, reg7])
+    }
+}
+
+impl Prover for MulFib8Prover {
+    type BaseField = BaseElement;
+    type AIR = MulFib8Air;
+
+    fn options(&self) -> &ProofOptions {
+        &self.options
+    }
+}

--- a/examples/src/fibonacci/mulfib8/prover.rs
+++ b/examples/src/fibonacci/mulfib8/prover.rs
@@ -1,3 +1,8 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 use super::{BaseElement, ExecutionTrace, MulFib8Air, ProofOptions, Prover};
 
 // FIBONACCI PROVER
@@ -46,7 +51,8 @@ impl MulFib8Prover {
 
 impl Prover for MulFib8Prover {
     type BaseField = BaseElement;
-    type AIR = MulFib8Air;
+    type Air = MulFib8Air;
+    type Trace = ExecutionTrace<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/fibonacci/mulfib8/prover.rs
+++ b/examples/src/fibonacci/mulfib8/prover.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{BaseElement, MulFib8Air, ProofOptions, Prover, TraceTable};
+use super::{BaseElement, MulFib8Air, ProofOptions, Prover, Trace, TraceTable};
 
 // FIBONACCI PROVER
 // ================================================================================================
@@ -53,6 +53,11 @@ impl Prover for MulFib8Prover {
     type BaseField = BaseElement;
     type Air = MulFib8Air;
     type Trace = TraceTable<BaseElement>;
+
+    fn get_pub_inputs(&self, trace: &Self::Trace) -> BaseElement {
+        let last_step = trace.length() - 1;
+        trace.get(6, last_step)
+    }
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/lamport/aggregate/air.rs
+++ b/examples/src/lamport/aggregate/air.rs
@@ -39,7 +39,7 @@ pub struct LamportAggregateAir {
 }
 
 impl Air for LamportAggregateAir {
-    type BaseElement = BaseElement;
+    type BaseField = BaseElement;
     type PublicInputs = PublicInputs;
 
     // CONSTRUCTOR
@@ -87,11 +87,11 @@ impl Air for LamportAggregateAir {
         }
     }
 
-    fn context(&self) -> &AirContext<Self::BaseElement> {
+    fn context(&self) -> &AirContext<Self::BaseField> {
         &self.context
     }
 
-    fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
         frame: &EvaluationFrame<E>,
         periodic_values: &[E],
@@ -121,7 +121,7 @@ impl Air for LamportAggregateAir {
         );
     }
 
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
         let last_cycle_step = SIG_CYCLE_LEN - 1;
         let messages = transpose(&self.messages);
         let pub_keys = transpose(&self.pub_keys);
@@ -160,7 +160,7 @@ impl Air for LamportAggregateAir {
         ]
     }
 
-    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseElement>> {
+    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseField>> {
         let mut result = vec![];
 
         // signature cycle mask: 1023 zeros followed by 1 one

--- a/examples/src/lamport/aggregate/air.rs
+++ b/examples/src/lamport/aggregate/air.rs
@@ -20,6 +20,7 @@ const TWO: BaseElement = BaseElement::new(2);
 // AGGREGATE LAMPORT PLUS SIGNATURE AIR
 // ================================================================================================
 
+#[derive(Clone)]
 pub struct PublicInputs {
     pub pub_keys: Vec<[BaseElement; 2]>,
     pub messages: Vec<[BaseElement; 2]>,

--- a/examples/src/lamport/aggregate/mod.rs
+++ b/examples/src/lamport/aggregate/mod.rs
@@ -10,15 +10,15 @@ use crate::ExampleOptions;
 use log::debug;
 use std::time::Instant;
 use winterfell::{
-    math::{fields::f128::BaseElement, log2},
-    ProofOptions, StarkProof, VerifierError,
+    math::{fields::f128::BaseElement, get_power_series, log2, FieldElement, StarkField},
+    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
 };
-
-mod trace;
-use trace::generate_trace;
 
 mod air;
 use air::{LamportAggregateAir, PublicInputs};
+
+mod prover;
+use prover::LamportAggregateProver;
 
 // CONSTANTS
 // ================================================================================================
@@ -113,8 +113,10 @@ impl Example for LamportAggregateExample {
             self.signatures.len(),
         );
 
+        let prover = LamportAggregateProver::new(self.options.clone());
+
         let now = Instant::now();
-        let trace = generate_trace(&self.messages, &self.signatures);
+        let trace = prover.build_trace(&self.messages, &self.signatures);
         let trace_length = trace.length();
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
@@ -123,12 +125,12 @@ impl Example for LamportAggregateExample {
             now.elapsed().as_millis()
         );
 
-        // generate the proof
+        // create a prover and generate the proof
         let pub_inputs = PublicInputs {
             pub_keys: self.pub_keys.clone(),
             messages: self.messages.clone(),
         };
-        winterfell::prove::<LamportAggregateAir>(trace, pub_inputs, self.options.clone()).unwrap()
+        prover.prove(trace, pub_inputs).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/lamport/aggregate/mod.rs
+++ b/examples/src/lamport/aggregate/mod.rs
@@ -11,7 +11,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, get_power_series, log2, FieldElement, StarkField},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
+    ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
 mod air;

--- a/examples/src/lamport/aggregate/mod.rs
+++ b/examples/src/lamport/aggregate/mod.rs
@@ -11,7 +11,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, get_power_series, log2, FieldElement, StarkField},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
+    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
 };
 
 mod air;

--- a/examples/src/lamport/aggregate/mod.rs
+++ b/examples/src/lamport/aggregate/mod.rs
@@ -113,7 +113,9 @@ impl Example for LamportAggregateExample {
             self.signatures.len(),
         );
 
-        let prover = LamportAggregateProver::new(self.options.clone());
+        // create a prover
+        let prover =
+            LamportAggregateProver::new(&self.pub_keys, &self.messages, self.options.clone());
 
         let now = Instant::now();
         let trace = prover.build_trace(&self.messages, &self.signatures);
@@ -125,12 +127,8 @@ impl Example for LamportAggregateExample {
             now.elapsed().as_millis()
         );
 
-        // create a prover and generate the proof
-        let pub_inputs = PublicInputs {
-            pub_keys: self.pub_keys.clone(),
-            messages: self.messages.clone(),
-        };
-        prover.prove(trace, pub_inputs).unwrap()
+        // generate the proof
+        prover.prove(trace).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/lamport/aggregate/prover.rs
+++ b/examples/src/lamport/aggregate/prover.rs
@@ -1,3 +1,8 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 use super::{
     get_power_series, rescue, BaseElement, ExecutionTrace, FieldElement, LamportAggregateAir,
     ProofOptions, Prover, Signature, StarkField, CYCLE_LENGTH, NUM_HASH_ROUNDS, SIG_CYCLE_LENGTH,
@@ -71,7 +76,8 @@ impl LamportAggregateProver {
 
 impl Prover for LamportAggregateProver {
     type BaseField = BaseElement;
-    type AIR = LamportAggregateAir;
+    type Air = LamportAggregateAir;
+    type Trace = ExecutionTrace<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/lamport/aggregate/prover.rs
+++ b/examples/src/lamport/aggregate/prover.rs
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{
-    get_power_series, rescue, BaseElement, ExecutionTrace, FieldElement, LamportAggregateAir,
-    ProofOptions, Prover, Signature, StarkField, CYCLE_LENGTH, NUM_HASH_ROUNDS, SIG_CYCLE_LENGTH,
+    get_power_series, rescue, BaseElement, FieldElement, LamportAggregateAir, ProofOptions, Prover,
+    Signature, StarkField, TraceTable, CYCLE_LENGTH, NUM_HASH_ROUNDS, SIG_CYCLE_LENGTH,
     TRACE_WIDTH,
 };
 
@@ -50,10 +50,10 @@ impl LamportAggregateProver {
         &self,
         messages: &[[BaseElement; 2]],
         signatures: &[Signature],
-    ) -> ExecutionTrace<BaseElement> {
+    ) -> TraceTable<BaseElement> {
         // allocate memory to hold the trace table
         let trace_length = SIG_CYCLE_LENGTH * messages.len();
-        let mut trace = ExecutionTrace::new(TRACE_WIDTH, trace_length);
+        let mut trace = TraceTable::new(TRACE_WIDTH, trace_length);
 
         let powers_of_two = get_power_series(TWO, 128);
 
@@ -77,7 +77,7 @@ impl LamportAggregateProver {
 impl Prover for LamportAggregateProver {
     type BaseField = BaseElement;
     type Air = LamportAggregateAir;
-    type Trace = ExecutionTrace<BaseElement>;
+    type Trace = TraceTable<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/lamport/aggregate/prover.rs
+++ b/examples/src/lamport/aggregate/prover.rs
@@ -5,8 +5,8 @@
 
 use super::{
     get_power_series, rescue, BaseElement, FieldElement, LamportAggregateAir, ProofOptions, Prover,
-    Signature, StarkField, TraceTable, CYCLE_LENGTH, NUM_HASH_ROUNDS, SIG_CYCLE_LENGTH,
-    TRACE_WIDTH,
+    PublicInputs, Signature, StarkField, TraceTable, CYCLE_LENGTH, NUM_HASH_ROUNDS,
+    SIG_CYCLE_LENGTH, TRACE_WIDTH,
 };
 
 #[cfg(feature = "concurrent")]
@@ -38,12 +38,24 @@ struct KeySchedule {
 // ================================================================================================
 
 pub struct LamportAggregateProver {
+    pub_inputs: PublicInputs,
     options: ProofOptions,
 }
 
 impl LamportAggregateProver {
-    pub fn new(options: ProofOptions) -> Self {
-        Self { options }
+    pub fn new(
+        pub_keys: &[[BaseElement; 2]],
+        messages: &[[BaseElement; 2]],
+        options: ProofOptions,
+    ) -> Self {
+        let pub_inputs = PublicInputs {
+            pub_keys: pub_keys.to_vec(),
+            messages: messages.to_vec(),
+        };
+        Self {
+            pub_inputs,
+            options,
+        }
     }
 
     pub fn build_trace(
@@ -78,6 +90,10 @@ impl Prover for LamportAggregateProver {
     type BaseField = BaseElement;
     type Air = LamportAggregateAir;
     type Trace = TraceTable<BaseElement>;
+
+    fn get_pub_inputs(&self, _trace: &Self::Trace) -> PublicInputs {
+        self.pub_inputs.clone()
+    }
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/lamport/threshold/air.rs
+++ b/examples/src/lamport/threshold/air.rs
@@ -21,6 +21,7 @@ const TWO: BaseElement = BaseElement::new(2);
 // THRESHOLD LAMPORT PLUS SIGNATURE AIR
 // ================================================================================================
 
+#[derive(Clone)]
 pub struct PublicInputs {
     pub pub_key_root: [BaseElement; 2],
     pub num_pub_keys: usize,

--- a/examples/src/lamport/threshold/air.rs
+++ b/examples/src/lamport/threshold/air.rs
@@ -46,7 +46,7 @@ pub struct LamportThresholdAir {
 }
 
 impl Air for LamportThresholdAir {
-    type BaseElement = BaseElement;
+    type BaseField = BaseElement;
     type PublicInputs = PublicInputs;
 
     // CONSTRUCTOR
@@ -102,7 +102,7 @@ impl Air for LamportThresholdAir {
         }
     }
 
-    fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
         frame: &EvaluationFrame<E>,
         periodic_values: &[E],
@@ -137,7 +137,7 @@ impl Air for LamportThresholdAir {
         );
     }
 
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
         // ----- assertions against the first step of every cycle: 0, 1024, 2048 etc. -------------
         let mut assertions = vec![
             // for private key hasher, last 4 state register should be set to zeros
@@ -197,7 +197,7 @@ impl Air for LamportThresholdAir {
         assertions
     }
 
-    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseElement>> {
+    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseField>> {
         let mut result = vec![];
 
         // signature cycle mask: 1023 zeros followed by 1 one
@@ -239,7 +239,7 @@ impl Air for LamportThresholdAir {
         result
     }
 
-    fn context(&self) -> &AirContext<Self::BaseElement> {
+    fn context(&self) -> &AirContext<Self::BaseField> {
         &self.context
     }
 }

--- a/examples/src/lamport/threshold/mod.rs
+++ b/examples/src/lamport/threshold/mod.rs
@@ -12,7 +12,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, get_power_series, log2, FieldElement, StarkField},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
+    ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
 mod signature;

--- a/examples/src/lamport/threshold/mod.rs
+++ b/examples/src/lamport/threshold/mod.rs
@@ -99,8 +99,15 @@ impl Example for LamportThresholdExample {
             self.pub_key.num_keys(),
         );
 
-        let prover = LamportThresholdProver::new(self.options.clone());
+        // create a prover
+        let prover = LamportThresholdProver::new(
+            &self.pub_key,
+            self.message,
+            &self.signatures,
+            self.options.clone(),
+        );
 
+        // generate execution trace
         let now = Instant::now();
         let trace = prover.build_trace(&self.pub_key, self.message, &self.signatures);
         let trace_length = trace.length();
@@ -111,14 +118,8 @@ impl Example for LamportThresholdExample {
             now.elapsed().as_millis()
         );
 
-        // create a prover and generate the proof
-        let pub_inputs = PublicInputs {
-            pub_key_root: self.pub_key.root().to_elements(),
-            num_pub_keys: self.pub_key.num_keys(),
-            num_signatures: self.signatures.len(),
-            message: self.message,
-        };
-        prover.prove(trace, pub_inputs).unwrap()
+        // generate the proof
+        prover.prove(trace).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/lamport/threshold/mod.rs
+++ b/examples/src/lamport/threshold/mod.rs
@@ -12,7 +12,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, get_power_series, log2, FieldElement, StarkField},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
+    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
 };
 
 mod signature;

--- a/examples/src/lamport/threshold/mod.rs
+++ b/examples/src/lamport/threshold/mod.rs
@@ -11,18 +11,18 @@ use crate::ExampleOptions;
 use log::debug;
 use std::time::Instant;
 use winterfell::{
-    math::{fields::f128::BaseElement, log2},
-    ProofOptions, StarkProof, VerifierError,
+    math::{fields::f128::BaseElement, get_power_series, log2, FieldElement, StarkField},
+    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
 };
 
 mod signature;
 use signature::AggPublicKey;
 
-mod trace;
-use trace::generate_trace;
-
 mod air;
 use air::{LamportThresholdAir, PublicInputs};
+
+mod prover;
+use prover::LamportThresholdProver;
 
 // CONSTANTS
 // ================================================================================================
@@ -99,8 +99,10 @@ impl Example for LamportThresholdExample {
             self.pub_key.num_keys(),
         );
 
+        let prover = LamportThresholdProver::new(self.options.clone());
+
         let now = Instant::now();
-        let trace = generate_trace(&self.pub_key, self.message, &self.signatures);
+        let trace = prover.build_trace(&self.pub_key, self.message, &self.signatures);
         let trace_length = trace.length();
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
@@ -109,14 +111,14 @@ impl Example for LamportThresholdExample {
             now.elapsed().as_millis()
         );
 
-        // generate the proof
+        // create a prover and generate the proof
         let pub_inputs = PublicInputs {
             pub_key_root: self.pub_key.root().to_elements(),
             num_pub_keys: self.pub_key.num_keys(),
             num_signatures: self.signatures.len(),
             message: self.message,
         };
-        winterfell::prove::<LamportThresholdAir>(trace, pub_inputs, self.options.clone()).unwrap()
+        prover.prove(trace, pub_inputs).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/lamport/threshold/prover.rs
+++ b/examples/src/lamport/threshold/prover.rs
@@ -1,3 +1,8 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 use super::{
     get_power_series, rescue, AggPublicKey, BaseElement, ExecutionTrace, FieldElement,
     LamportThresholdAir, ProofOptions, Prover, Signature, StarkField, HASH_CYCLE_LENGTH,
@@ -109,7 +114,8 @@ impl LamportThresholdProver {
 
 impl Prover for LamportThresholdProver {
     type BaseField = BaseElement;
-    type AIR = LamportThresholdAir;
+    type Air = LamportThresholdAir;
+    type Trace = ExecutionTrace<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/lamport/threshold/prover.rs
+++ b/examples/src/lamport/threshold/prover.rs
@@ -4,9 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{
-    get_power_series, rescue, AggPublicKey, BaseElement, ExecutionTrace, FieldElement,
-    LamportThresholdAir, ProofOptions, Prover, Signature, StarkField, HASH_CYCLE_LENGTH,
-    NUM_HASH_ROUNDS, SIG_CYCLE_LENGTH, TRACE_WIDTH,
+    get_power_series, rescue, AggPublicKey, BaseElement, FieldElement, LamportThresholdAir,
+    ProofOptions, Prover, Signature, StarkField, TraceTable, HASH_CYCLE_LENGTH, NUM_HASH_ROUNDS,
+    SIG_CYCLE_LENGTH, TRACE_WIDTH,
 };
 use std::collections::HashMap;
 
@@ -57,11 +57,11 @@ impl LamportThresholdProver {
         pub_key: &AggPublicKey,
         message: [BaseElement; 2],
         signatures: &[(usize, Signature)],
-    ) -> ExecutionTrace<BaseElement> {
+    ) -> TraceTable<BaseElement> {
         // allocate memory to hold the trace table
         let num_cycles = pub_key.num_keys().next_power_of_two();
         let trace_length = SIG_CYCLE_LENGTH * num_cycles;
-        let mut trace = ExecutionTrace::new(TRACE_WIDTH, trace_length);
+        let mut trace = TraceTable::new(TRACE_WIDTH, trace_length);
 
         let powers_of_two = get_power_series(TWO, 128);
 
@@ -115,7 +115,7 @@ impl LamportThresholdProver {
 impl Prover for LamportThresholdProver {
     type BaseField = BaseElement;
     type Air = LamportThresholdAir;
-    type Trace = ExecutionTrace<BaseElement>;
+    type Trace = TraceTable<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/merkle/air.rs
+++ b/examples/src/merkle/air.rs
@@ -3,24 +3,12 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use crate::utils::{
-    are_equal, is_binary, is_zero, not,
-    rescue::{
-        self, CYCLE_LENGTH as HASH_CYCLE_LEN, NUM_ROUNDS as NUM_HASH_ROUNDS,
-        STATE_WIDTH as HASH_STATE_WIDTH,
-    },
-    EvaluationResult,
-};
+use super::{rescue, BaseElement, FieldElement, HASH_CYCLE_LEN, HASH_STATE_WIDTH, TRACE_WIDTH};
+use crate::utils::{are_equal, is_binary, is_zero, not, EvaluationResult};
 use winterfell::{
-    math::{fields::f128::BaseElement, FieldElement},
-    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, ExecutionTrace, ProofOptions,
-    Serializable, TraceInfo, TransitionConstraintDegree,
+    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, ProofOptions, Serializable, TraceInfo,
+    TransitionConstraintDegree,
 };
-
-// CONSTANTS
-// ================================================================================================
-
-const TRACE_WIDTH: usize = 7;
 
 // MERKLE PATH VERIFICATION AIR
 // ================================================================================================
@@ -128,75 +116,6 @@ impl Air for MerkleAir {
         result.append(&mut rescue::get_round_constants());
         result
     }
-}
-
-// TRACE GENERATOR
-// ================================================================================================
-
-pub fn build_trace(
-    value: [BaseElement; 2],
-    branch: &[rescue::Hash],
-    index: usize,
-) -> ExecutionTrace<BaseElement> {
-    // allocate memory to hold the trace table
-    let trace_length = branch.len() * HASH_CYCLE_LEN;
-    let mut trace = ExecutionTrace::new(TRACE_WIDTH, trace_length);
-
-    // skip the first node of the branch because it will be computed in the trace as hash(value)
-    let branch = &branch[1..];
-
-    trace.fill(
-        |state| {
-            // initialize first state of the computation
-            state[0] = value[0];
-            state[1] = value[1];
-            state[2..].fill(BaseElement::ZERO);
-        },
-        |step, state| {
-            // execute the transition function for all steps
-            //
-            // For the first 7 steps of each 8-step cycle, compute a single round of Rescue hash in
-            // registers [0..6]. On the 8th step, insert the next branch node into the trace in the
-            // positions defined by the next bit of the leaf index. If the bit is ZERO, the next node
-            // goes into registers [2, 3], if it is ONE, the node goes into registers [0, 1].
-
-            let cycle_num = step / HASH_CYCLE_LEN;
-            let cycle_pos = step % HASH_CYCLE_LEN;
-
-            if cycle_pos < NUM_HASH_ROUNDS {
-                rescue::apply_round(&mut state[..HASH_STATE_WIDTH], step);
-            } else {
-                let branch_node = branch[cycle_num].to_elements();
-                let index_bit = BaseElement::new(((index >> cycle_num) & 1) as u128);
-                if index_bit == BaseElement::ZERO {
-                    // if index bit is zero, new branch node goes into registers [2, 3]; values in
-                    // registers [0, 1] (the accumulated hash) remain unchanged
-                    state[2] = branch_node[0];
-                    state[3] = branch_node[1];
-                } else {
-                    // if index bit is one, accumulated hash goes into registers [2, 3],
-                    // and new branch nodes goes into registers [0, 1]
-                    state[2] = state[0];
-                    state[3] = state[1];
-                    state[0] = branch_node[0];
-                    state[1] = branch_node[1];
-                }
-                // reset the capacity registers of the state to ZERO
-                state[4] = BaseElement::ZERO;
-                state[5] = BaseElement::ZERO;
-
-                state[6] = index_bit;
-            }
-        },
-    );
-
-    // set index bit at the second step to one; this still results in a valid execution trace
-    // because actual index bits are inserted into the trace after step 7, but it ensures
-    // that there are no repeating patterns in the index bit register, and thus the degree
-    // of the index bit constraint is stable.
-    trace.set(6, 1, FieldElement::ONE);
-
-    trace
 }
 
 // MASKS

--- a/examples/src/merkle/air.rs
+++ b/examples/src/merkle/air.rs
@@ -29,7 +29,7 @@ pub struct MerkleAir {
 }
 
 impl Air for MerkleAir {
-    type BaseElement = BaseElement;
+    type BaseField = BaseElement;
     type PublicInputs = PublicInputs;
 
     // CONSTRUCTOR
@@ -51,11 +51,11 @@ impl Air for MerkleAir {
         }
     }
 
-    fn context(&self) -> &AirContext<Self::BaseElement> {
+    fn context(&self) -> &AirContext<Self::BaseField> {
         &self.context
     }
 
-    fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
         frame: &EvaluationFrame<E>,
         periodic_values: &[E],
@@ -99,7 +99,7 @@ impl Air for MerkleAir {
         result[6] = is_binary(current[6]);
     }
 
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
         // assert that Merkle path resolves to the tree root, and that hash capacity
         // registers (registers 4 and 5) are reset to ZERO every 8 steps
         let last_step = self.trace_length() - 1;
@@ -111,7 +111,7 @@ impl Air for MerkleAir {
         ]
     }
 
-    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseElement>> {
+    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseField>> {
         let mut result = vec![HASH_CYCLE_MASK.to_vec()];
         result.append(&mut rescue::get_round_constants());
         result

--- a/examples/src/merkle/mod.rs
+++ b/examples/src/merkle/mod.rs
@@ -3,6 +3,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use crate::utils::rescue::{
+    self, CYCLE_LENGTH as HASH_CYCLE_LEN, NUM_ROUNDS as NUM_HASH_ROUNDS,
+    STATE_WIDTH as HASH_STATE_WIDTH,
+};
 use crate::{
     utils::rescue::{Hash, Rescue128},
     Example, ExampleOptions,
@@ -12,15 +16,23 @@ use rand_utils::{rand_value, rand_vector};
 use std::time::Instant;
 use winterfell::{
     crypto::{Digest, MerkleTree},
-    math::{fields::f128::BaseElement, log2, StarkField},
-    ProofOptions, StarkProof, VerifierError,
+    math::{fields::f128::BaseElement, log2, FieldElement, StarkField},
+    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
 };
 
 mod air;
-use air::{build_trace, MerkleAir, PublicInputs};
+use air::{MerkleAir, PublicInputs};
+
+mod prover;
+use prover::MerkleProver;
 
 #[cfg(test)]
 mod tests;
+
+// CONSTANTS
+// ================================================================================================
+
+const TRACE_WIDTH: usize = 7;
 
 // MERKLE AUTHENTICATION PATH EXAMPLE
 // ================================================================================================
@@ -89,8 +101,10 @@ impl Example for MerkleExample {
             ---------------------",
             self.path.len()
         );
+        let prover = MerkleProver::new(self.options.clone());
+
         let now = Instant::now();
-        let trace = build_trace(self.value, &self.path, self.index);
+        let trace = prover.build_trace(self.value, &self.path, self.index);
         let trace_length = trace.length();
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
@@ -103,7 +117,7 @@ impl Example for MerkleExample {
         let pub_inputs = PublicInputs {
             tree_root: self.tree_root.to_elements(),
         };
-        winterfell::prove::<MerkleAir>(trace, pub_inputs, self.options.clone()).unwrap()
+        prover.prove(trace, pub_inputs).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/merkle/mod.rs
+++ b/examples/src/merkle/mod.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 use winterfell::{
     crypto::{Digest, MerkleTree},
     math::{fields::f128::BaseElement, log2, FieldElement, StarkField},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
+    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
 };
 
 mod air;

--- a/examples/src/merkle/mod.rs
+++ b/examples/src/merkle/mod.rs
@@ -101,8 +101,10 @@ impl Example for MerkleExample {
             ---------------------",
             self.path.len()
         );
+        // create the prover
         let prover = MerkleProver::new(self.options.clone());
 
+        // generate the execution trace
         let now = Instant::now();
         let trace = prover.build_trace(self.value, &self.path, self.index);
         let trace_length = trace.length();
@@ -114,10 +116,7 @@ impl Example for MerkleExample {
         );
 
         // generate the proof
-        let pub_inputs = PublicInputs {
-            tree_root: self.tree_root.to_elements(),
-        };
-        prover.prove(trace, pub_inputs).unwrap()
+        prover.prove(trace).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/merkle/mod.rs
+++ b/examples/src/merkle/mod.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 use winterfell::{
     crypto::{Digest, MerkleTree},
     math::{fields::f128::BaseElement, log2, FieldElement, StarkField},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
+    ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
 mod air;

--- a/examples/src/merkle/prover.rs
+++ b/examples/src/merkle/prover.rs
@@ -1,0 +1,94 @@
+use super::{
+    rescue, BaseElement, ExecutionTrace, FieldElement, MerkleAir, ProofOptions, Prover,
+    HASH_CYCLE_LEN, HASH_STATE_WIDTH, NUM_HASH_ROUNDS, TRACE_WIDTH,
+};
+
+// MERKLE PROVER
+// ================================================================================================
+
+pub struct MerkleProver {
+    options: ProofOptions,
+}
+
+impl MerkleProver {
+    pub fn new(options: ProofOptions) -> Self {
+        Self { options }
+    }
+
+    pub fn build_trace(
+        &self,
+        value: [BaseElement; 2],
+        branch: &[rescue::Hash],
+        index: usize,
+    ) -> ExecutionTrace<BaseElement> {
+        // allocate memory to hold the trace table
+        let trace_length = branch.len() * HASH_CYCLE_LEN;
+        let mut trace = ExecutionTrace::new(TRACE_WIDTH, trace_length);
+
+        // skip the first node of the branch because it will be computed in the trace as hash(value)
+        let branch = &branch[1..];
+
+        trace.fill(
+            |state| {
+                // initialize first state of the computation
+                state[0] = value[0];
+                state[1] = value[1];
+                state[2..].fill(BaseElement::ZERO);
+            },
+            |step, state| {
+                // execute the transition function for all steps
+                //
+                // For the first 7 steps of each 8-step cycle, compute a single round of Rescue
+                // hash in registers [0..6]. On the 8th step, insert the next branch node into the
+                // trace in the positions defined by the next bit of the leaf index. If the bit is
+                // ZERO, the next node goes into registers [2, 3], if it is ONE, the node goes into
+                // registers [0, 1].
+
+                let cycle_num = step / HASH_CYCLE_LEN;
+                let cycle_pos = step % HASH_CYCLE_LEN;
+
+                if cycle_pos < NUM_HASH_ROUNDS {
+                    rescue::apply_round(&mut state[..HASH_STATE_WIDTH], step);
+                } else {
+                    let branch_node = branch[cycle_num].to_elements();
+                    let index_bit = BaseElement::new(((index >> cycle_num) & 1) as u128);
+                    if index_bit == BaseElement::ZERO {
+                        // if index bit is zero, new branch node goes into registers [2, 3]; values
+                        // in registers [0, 1] (the accumulated hash) remain unchanged
+                        state[2] = branch_node[0];
+                        state[3] = branch_node[1];
+                    } else {
+                        // if index bit is one, accumulated hash goes into registers [2, 3],
+                        // and new branch nodes goes into registers [0, 1]
+                        state[2] = state[0];
+                        state[3] = state[1];
+                        state[0] = branch_node[0];
+                        state[1] = branch_node[1];
+                    }
+                    // reset the capacity registers of the state to ZERO
+                    state[4] = BaseElement::ZERO;
+                    state[5] = BaseElement::ZERO;
+
+                    state[6] = index_bit;
+                }
+            },
+        );
+
+        // set index bit at the second step to one; this still results in a valid execution trace
+        // because actual index bits are inserted into the trace after step 7, but it ensures
+        // that there are no repeating patterns in the index bit register, and thus the degree
+        // of the index bit constraint is stable.
+        trace.set(6, 1, FieldElement::ONE);
+
+        trace
+    }
+}
+
+impl Prover for MerkleProver {
+    type BaseField = BaseElement;
+    type AIR = MerkleAir;
+
+    fn options(&self) -> &ProofOptions {
+        &self.options
+    }
+}

--- a/examples/src/merkle/prover.rs
+++ b/examples/src/merkle/prover.rs
@@ -1,3 +1,8 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 use super::{
     rescue, BaseElement, ExecutionTrace, FieldElement, MerkleAir, ProofOptions, Prover,
     HASH_CYCLE_LEN, HASH_STATE_WIDTH, NUM_HASH_ROUNDS, TRACE_WIDTH,
@@ -86,7 +91,8 @@ impl MerkleProver {
 
 impl Prover for MerkleProver {
     type BaseField = BaseElement;
-    type AIR = MerkleAir;
+    type Air = MerkleAir;
+    type Trace = ExecutionTrace<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/merkle/prover.rs
+++ b/examples/src/merkle/prover.rs
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{
-    rescue, BaseElement, FieldElement, MerkleAir, ProofOptions, Prover, TraceTable, HASH_CYCLE_LEN,
-    HASH_STATE_WIDTH, NUM_HASH_ROUNDS, TRACE_WIDTH,
+    rescue, BaseElement, FieldElement, MerkleAir, ProofOptions, Prover, PublicInputs, Trace,
+    TraceTable, HASH_CYCLE_LEN, HASH_STATE_WIDTH, NUM_HASH_ROUNDS, TRACE_WIDTH,
 };
 
 // MERKLE PROVER
@@ -93,6 +93,13 @@ impl Prover for MerkleProver {
     type BaseField = BaseElement;
     type Air = MerkleAir;
     type Trace = TraceTable<BaseElement>;
+
+    fn get_pub_inputs(&self, trace: &Self::Trace) -> PublicInputs {
+        let last_step = trace.length() - 1;
+        PublicInputs {
+            tree_root: [trace.get(0, last_step), trace.get(1, last_step)],
+        }
+    }
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/merkle/prover.rs
+++ b/examples/src/merkle/prover.rs
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{
-    rescue, BaseElement, ExecutionTrace, FieldElement, MerkleAir, ProofOptions, Prover,
-    HASH_CYCLE_LEN, HASH_STATE_WIDTH, NUM_HASH_ROUNDS, TRACE_WIDTH,
+    rescue, BaseElement, FieldElement, MerkleAir, ProofOptions, Prover, TraceTable, HASH_CYCLE_LEN,
+    HASH_STATE_WIDTH, NUM_HASH_ROUNDS, TRACE_WIDTH,
 };
 
 // MERKLE PROVER
@@ -25,10 +25,10 @@ impl MerkleProver {
         value: [BaseElement; 2],
         branch: &[rescue::Hash],
         index: usize,
-    ) -> ExecutionTrace<BaseElement> {
+    ) -> TraceTable<BaseElement> {
         // allocate memory to hold the trace table
         let trace_length = branch.len() * HASH_CYCLE_LEN;
-        let mut trace = ExecutionTrace::new(TRACE_WIDTH, trace_length);
+        let mut trace = TraceTable::new(TRACE_WIDTH, trace_length);
 
         // skip the first node of the branch because it will be computed in the trace as hash(value)
         let branch = &branch[1..];
@@ -92,7 +92,7 @@ impl MerkleProver {
 impl Prover for MerkleProver {
     type BaseField = BaseElement;
     type Air = MerkleAir;
-    type Trace = ExecutionTrace<BaseElement>;
+    type Trace = TraceTable<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/rescue/air.rs
+++ b/examples/src/rescue/air.rs
@@ -55,7 +55,7 @@ pub struct RescueAir {
 }
 
 impl Air for RescueAir {
-    type BaseElement = BaseElement;
+    type BaseField = BaseElement;
     type PublicInputs = PublicInputs;
 
     // CONSTRUCTOR
@@ -75,11 +75,11 @@ impl Air for RescueAir {
         }
     }
 
-    fn context(&self) -> &AirContext<Self::BaseElement> {
+    fn context(&self) -> &AirContext<Self::BaseField> {
         &self.context
     }
 
-    fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
         frame: &EvaluationFrame<E>,
         periodic_values: &[E],
@@ -104,7 +104,7 @@ impl Air for RescueAir {
         enforce_hash_copy(result, current, next, copy_flag);
     }
 
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
         // Assert starting and ending values of the hash chain
         let last_step = self.trace_length() - 1;
         vec![
@@ -115,7 +115,7 @@ impl Air for RescueAir {
         ]
     }
 
-    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseElement>> {
+    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseField>> {
         let mut result = vec![CYCLE_MASK.to_vec()];
         result.append(&mut rescue::get_round_constants());
         result

--- a/examples/src/rescue/mod.rs
+++ b/examples/src/rescue/mod.rs
@@ -8,7 +8,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
+    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
 };
 
 #[allow(clippy::module_inception)]

--- a/examples/src/rescue/mod.rs
+++ b/examples/src/rescue/mod.rs
@@ -8,17 +8,27 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ProofOptions, StarkProof, VerifierError,
+    ExecutionTrace, ProofOptions, Prover, StarkProof, VerifierError,
 };
 
 #[allow(clippy::module_inception)]
 mod rescue;
 
 mod air;
-use air::{build_trace, PublicInputs, RescueAir};
+use air::{PublicInputs, RescueAir};
+
+mod prover;
+use prover::RescueProver;
 
 #[cfg(test)]
 mod tests;
+
+// CONSTANTS
+// ================================================================================================
+
+const CYCLE_LENGTH: usize = 16;
+const NUM_HASH_ROUNDS: usize = 14;
+const TRACE_WIDTH: usize = 4;
 
 // RESCUE HASH CHAIN EXAMPLE
 // ================================================================================================
@@ -74,8 +84,11 @@ impl Example for RescueExample {
             ---------------------",
             self.chain_length
         );
+
+        let prover = RescueProver::new(self.options.clone());
+
         let now = Instant::now();
-        let trace = build_trace(self.seed, self.chain_length);
+        let trace = prover.build_trace(self.seed, self.chain_length);
         let trace_length = trace.length();
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
@@ -89,7 +102,7 @@ impl Example for RescueExample {
             seed: self.seed,
             result: self.result,
         };
-        winterfell::prove::<RescueAir>(trace, pub_inputs, self.options.clone()).unwrap()
+        prover.prove(trace, pub_inputs).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/rescue/mod.rs
+++ b/examples/src/rescue/mod.rs
@@ -8,7 +8,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement},
-    ExecutionTrace, ProofOptions, Prover, StarkProof, Trace, VerifierError,
+    ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
 #[allow(clippy::module_inception)]

--- a/examples/src/rescue/mod.rs
+++ b/examples/src/rescue/mod.rs
@@ -85,8 +85,10 @@ impl Example for RescueExample {
             self.chain_length
         );
 
+        // create a prover
         let prover = RescueProver::new(self.options.clone());
 
+        // generate the execution trace
         let now = Instant::now();
         let trace = prover.build_trace(self.seed, self.chain_length);
         let trace_length = trace.length();
@@ -98,11 +100,7 @@ impl Example for RescueExample {
         );
 
         // generate the proof
-        let pub_inputs = PublicInputs {
-            seed: self.seed,
-            result: self.result,
-        };
-        prover.prove(trace, pub_inputs).unwrap()
+        prover.prove(trace).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {

--- a/examples/src/rescue/prover.rs
+++ b/examples/src/rescue/prover.rs
@@ -1,0 +1,61 @@
+use super::{
+    rescue, BaseElement, ExecutionTrace, FieldElement, ProofOptions, Prover, RescueAir,
+    CYCLE_LENGTH, NUM_HASH_ROUNDS,
+};
+
+// RESCUE PROVER
+// ================================================================================================
+
+pub struct RescueProver {
+    options: ProofOptions,
+}
+
+impl RescueProver {
+    pub fn new(options: ProofOptions) -> Self {
+        Self { options }
+    }
+
+    pub fn build_trace(
+        &self,
+        seed: [BaseElement; 2],
+        iterations: usize,
+    ) -> ExecutionTrace<BaseElement> {
+        // allocate memory to hold the trace table
+        let trace_length = iterations * CYCLE_LENGTH;
+        let mut trace = ExecutionTrace::new(4, trace_length);
+
+        trace.fill(
+            |state| {
+                // initialize first state of the computation
+                state[0] = seed[0];
+                state[1] = seed[1];
+                state[2] = BaseElement::ZERO;
+                state[3] = BaseElement::ZERO;
+            },
+            |step, state| {
+                // execute the transition function for all steps
+                //
+                // for the first 14 steps in every cycle, compute a single round of
+                // Rescue hash; for the remaining 2 rounds, just carry over the values
+                // in the first two registers to the next step
+                if (step % CYCLE_LENGTH) < NUM_HASH_ROUNDS {
+                    rescue::apply_round(state, step);
+                } else {
+                    state[2] = BaseElement::ZERO;
+                    state[3] = BaseElement::ZERO;
+                }
+            },
+        );
+
+        trace
+    }
+}
+
+impl Prover for RescueProver {
+    type BaseField = BaseElement;
+    type AIR = RescueAir;
+
+    fn options(&self) -> &ProofOptions {
+        &self.options
+    }
+}

--- a/examples/src/rescue/prover.rs
+++ b/examples/src/rescue/prover.rs
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{
-    rescue, BaseElement, ExecutionTrace, FieldElement, ProofOptions, Prover, RescueAir,
-    CYCLE_LENGTH, NUM_HASH_ROUNDS,
+    rescue, BaseElement, FieldElement, ProofOptions, Prover, RescueAir, TraceTable, CYCLE_LENGTH,
+    NUM_HASH_ROUNDS,
 };
 
 // RESCUE PROVER
@@ -24,10 +24,10 @@ impl RescueProver {
         &self,
         seed: [BaseElement; 2],
         iterations: usize,
-    ) -> ExecutionTrace<BaseElement> {
+    ) -> TraceTable<BaseElement> {
         // allocate memory to hold the trace table
         let trace_length = iterations * CYCLE_LENGTH;
-        let mut trace = ExecutionTrace::new(4, trace_length);
+        let mut trace = TraceTable::new(4, trace_length);
 
         trace.fill(
             |state| {
@@ -59,7 +59,7 @@ impl RescueProver {
 impl Prover for RescueProver {
     type BaseField = BaseElement;
     type Air = RescueAir;
-    type Trace = ExecutionTrace<BaseElement>;
+    type Trace = TraceTable<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/rescue/prover.rs
+++ b/examples/src/rescue/prover.rs
@@ -1,3 +1,8 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 use super::{
     rescue, BaseElement, ExecutionTrace, FieldElement, ProofOptions, Prover, RescueAir,
     CYCLE_LENGTH, NUM_HASH_ROUNDS,
@@ -53,7 +58,8 @@ impl RescueProver {
 
 impl Prover for RescueProver {
     type BaseField = BaseElement;
-    type AIR = RescueAir;
+    type Air = RescueAir;
+    type Trace = ExecutionTrace<BaseElement>;
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/rescue/prover.rs
+++ b/examples/src/rescue/prover.rs
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{
-    rescue, BaseElement, FieldElement, ProofOptions, Prover, RescueAir, TraceTable, CYCLE_LENGTH,
-    NUM_HASH_ROUNDS,
+    rescue, BaseElement, FieldElement, ProofOptions, Prover, PublicInputs, RescueAir, Trace,
+    TraceTable, CYCLE_LENGTH, NUM_HASH_ROUNDS,
 };
 
 // RESCUE PROVER
@@ -60,6 +60,14 @@ impl Prover for RescueProver {
     type BaseField = BaseElement;
     type Air = RescueAir;
     type Trace = TraceTable<BaseElement>;
+
+    fn get_pub_inputs(&self, trace: &Self::Trace) -> PublicInputs {
+        let last_step = trace.length() - 1;
+        PublicInputs {
+            seed: [trace.get(0, 0), trace.get(1, 0)],
+            result: [trace.get(0, last_step), trace.get(1, last_step)],
+        }
+    }
 
     fn options(&self) -> &ProofOptions {
         &self.options

--- a/examples/src/utils/mod.rs
+++ b/examples/src/utils/mod.rs
@@ -6,7 +6,7 @@
 use core::ops::Range;
 use winterfell::{
     math::{fields::f128::BaseElement, FieldElement, StarkField},
-    ExecutionTrace, Trace,
+    Trace, TraceTable,
 };
 
 pub mod rescue;
@@ -59,7 +59,7 @@ impl<E: FieldElement> EvaluationResult<E> for Vec<E> {
 
 /// Prints out an execution trace.
 pub fn print_trace(
-    trace: &ExecutionTrace<BaseElement>,
+    trace: &TraceTable<BaseElement>,
     multiples_of: usize,
     offset: usize,
     range: Range<usize>,

--- a/examples/src/utils/mod.rs
+++ b/examples/src/utils/mod.rs
@@ -6,7 +6,7 @@
 use core::ops::Range;
 use winterfell::{
     math::{fields::f128::BaseElement, FieldElement, StarkField},
-    ExecutionTrace,
+    ExecutionTrace, Trace,
 };
 
 pub mod rescue;

--- a/prover/README.md
+++ b/prover/README.md
@@ -7,38 +7,35 @@ This prover can be used to generate proof of computational integrity using the S
 To generate a proof that a computation was executed correctly, you will need to do the following:
 
 1. Define *algebraic intermediate representation* (AIR) for your computation. This can be done by implementing `Air` trait (see [air crate](../air) for more info).
-2. Execute your computation and record its [execution trace](#Execution-trace).
-
-Then, to generate the proof you can use `prover::prove()` function, which has the following signature:
-```Rust
-pub fn prove<AIR: Air>(
-    trace: ExecutionTrace<AIR::BaseElement>,
-    pub_inputs: AIR::PublicInputs,
-    options: ProofOptions,
-) -> Result<StarkProof, ProverError>
-```
-where:
-
-* `AIR` is a type implementing `Air` trait for your computation.
-* `trace` is the execution trace of the computation executed against some set of public inputs.
-* `pub_inputs` is the set of public inputs against which the computation was executed. These inputs will need to be shared with the verifier in order for them to verify the proof.
-* `options` defines basic properties for proof generation such as: number of queries, blowup factor, grinding factor, hash function to be used during proof generation etc.. These properties directly inform such metrics as proof generation time, proof size, and proof security level. See [air crate](../air) for more info.
+2. Define an [execution trace](#Execution-trace) for your computation. This can be done by implementing `Trace` trait. Alternatively, you can use `TraceTable` struct which already implements `Trace` trait in cases when this generic implementation works for your use case.
+3. Execute your computation and record its execution trace.
+4. Define your prover(#Prover) by implementing `Prover` trait. Then execute `Prover::prove()` function passing the trace generated in the previous step into it as a parameter. The function will return a instance of `StarkProof`.
 
 The resulting `StarkProof` object can be serialized and sent to a [verifier](../verifier) for verification. The size of proof depends on the specifics of a given computation, but for most computations it should be in the range between 15 KB (for very small computations) and 300 KB (for very large computations).
 
 Proof generation time is also highly dependent on the specifics of a given computation, but also depends on the capabilities of the machine used to generate the proofs (i.e. on number of CPU cores and memory bandwidth). For some high level benchmarks, see the [performance](..#Performance) section of the root README.
 
+### Prover
+To define a prover for a computation, you'll need implement the `Prover` trait. This trait specifies the computation's AIR (via the `Air` associated type) and the shape of its execution trace (via the `Trace` associated type). Besides these, a prover must provide implementations for two methods:
+
+* `get_pub_inputs()`, which describes how a set of public inputs can be extracted from a given instance of an execution trace. These inputs will need to be shared with the verifier in order for them to verify the proof.
+* `options()`, which defines STARK protocol parameters to be used during proof generation. These parameters include number of queries, blowup factor, grinding factor, hash function to be used during proof generation etc.. Values of these parameters directly inform such metrics as proof generation time, proof size, and proof security level. See [air crate](../air) for more info.
+
+A prover exposes a `prove()` method which can be used to generate a STARK proof using a given execution trace as a witness.
+
 ### Execution trace
 Execution trace is a two-dimensional matrix in which each row represents the state of the computation at a single point in time and each column corresponds to an algebraic register tracked over all steps of the computation. A big part of defining AIR for a computation is coming up with an efficient way to represent the computation's execution trace. Check out the [examples crate](../examples) for more info.
 
-In Winterfell, an execution trace can be represented using an `ExecutionTrace` struct. There are two ways to instantiate this struct.
+In Winterfell, an execution trace can be represented by any struct which implements the `Trace` trait. This trait defines a few property accessors (e.g., width and length) and defines a way of converting the struct into a vector of columns.
 
-First, you can use the `ExecutionTrace::init()` function which takes a set of vectors as a parameter, where each vector contains values for a given column of the trace. This approach allows you to build the execution trace as you see fit, as long as it meets basic execution trace requirements. These requirements are:
+In most cases, defining a custom structure for an execution trace may be an overkill. Thus, Winterfell also provides a `TraceTable` struct which already implements the `Trace` trait. There are two ways to instantiate this struct.
+
+First, you can use the `TraceTable::init()` function which takes a set of vectors as a parameter, where each vector contains values for a given column of the trace. This approach allows you to build the execution trace as you see fit, as long as it meets basic execution trace requirements. These requirements are:
 
 1. Lengths of all columns in the execution trace must be the same.
 2. The length of the columns must be some power of two.
 
-The other approach is to instantiate `ExecutionTrace` struct using `ExecutionTrace::new()` function, which takes trace width and length as parameters. This function will allocate memory for the trace, but will not fill it with data. To fill the execution trace, you can use the `fill()` method, which takes two closures as parameters:
+The other approach is to instantiate `TraceTable` struct using `TraceTable::new()` function, which takes trace width and length as parameters. This function will allocate memory for the trace, but will not fill it with data. To fill the execution trace, you can use the `fill()` method, which takes two closures as parameters:
 
 1. The first closure is responsible for initializing the first state of the computation (the first row of the execution trace).
 2. The second closure receives the previous state of the execution trace as input, and must update it to the next state of the computation.
@@ -59,7 +56,7 @@ When this crate is compiled with `concurrent` feature enabled, proof generation 
 
 For computations which consist of many small independent computations, we can generate the execution trace of the entire computation by building fragments of the trace in parallel, and then joining these fragments together.
 
-For this purpose, `ExecutionTrace` struct exposes `fragments()` method, which takes fragment length as a parameter, breaks the execution trace into equally sized fragments, and returns an iterator over these fragments. You can then use fragment's `fill()` method to fill all fragments with data in parallel. The semantics of the fragment's `fill()` method are identical to the `fill()` method of the execution trace.
+For this purpose, `TraceTable` struct exposes `fragments()` method, which takes fragment length as a parameter, breaks the execution trace into equally sized fragments, and returns an iterator over these fragments. You can then use fragment's `fill()` method to fill all fragments with data in parallel. The semantics of the fragment's `fill()` method are identical to the `fill()` method of the execution trace.
 
 License
 -------

--- a/prover/src/channel.rs
+++ b/prover/src/channel.rs
@@ -22,11 +22,11 @@ use utils::iterators::*;
 pub struct ProverChannel<'a, A, E, H>
 where
     A: Air,
-    E: FieldElement<BaseField = A::BaseElement>,
-    H: ElementHasher<BaseField = A::BaseElement>,
+    E: FieldElement<BaseField = A::BaseField>,
+    H: ElementHasher<BaseField = A::BaseField>,
 {
     air: &'a A,
-    public_coin: RandomCoin<A::BaseElement, H>,
+    public_coin: RandomCoin<A::BaseField, H>,
     context: Context,
     commitments: Commitments,
     ood_frame: OodFrame,
@@ -40,14 +40,14 @@ where
 impl<'a, A, E, H> ProverChannel<'a, A, E, H>
 where
     A: Air,
-    E: FieldElement<BaseField = A::BaseElement>,
-    H: ElementHasher<BaseField = A::BaseElement>,
+    E: FieldElement<BaseField = A::BaseField>,
+    H: ElementHasher<BaseField = A::BaseField>,
 {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Creates a new prover channel for the specified `air` and public inputs.
     pub fn new(air: &'a A, pub_inputs_bytes: Vec<u8>) -> Self {
-        let context = Context::new::<A::BaseElement>(air.trace_info(), air.options().clone());
+        let context = Context::new::<A::BaseField>(air.trace_info(), air.options().clone());
 
         // build a seed for the public coin; the initial seed is the hash of public inputs and proof
         // context, but as the protocol progresses, the coin will be reseeded with the info sent to
@@ -179,8 +179,8 @@ where
 impl<'a, A, E, H> fri::ProverChannel<E> for ProverChannel<'a, A, E, H>
 where
     A: Air,
-    E: FieldElement<BaseField = A::BaseElement>,
-    H: ElementHasher<BaseField = A::BaseElement>,
+    E: FieldElement<BaseField = A::BaseField>,
+    H: ElementHasher<BaseField = A::BaseField>,
 {
     type Hasher = H;
 

--- a/prover/src/composer/mod.rs
+++ b/prover/src/composer/mod.rs
@@ -14,7 +14,7 @@ use utils::iterators::*;
 
 // DEEP COMPOSITION POLYNOMIAL
 // ================================================================================================
-pub struct DeepCompositionPoly<A: Air, E: FieldElement<BaseField = A::BaseElement>> {
+pub struct DeepCompositionPoly<A: Air, E: FieldElement<BaseField = A::BaseField>> {
     coefficients: Vec<E>,
     cc: DeepCompositionCoefficients<E>,
     z: E,
@@ -22,7 +22,7 @@ pub struct DeepCompositionPoly<A: Air, E: FieldElement<BaseField = A::BaseElemen
     _air: PhantomData<A>,
 }
 
-impl<A: Air, E: FieldElement<BaseField = A::BaseElement>> DeepCompositionPoly<A, E> {
+impl<A: Air, E: FieldElement<BaseField = A::BaseField>> DeepCompositionPoly<A, E> {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Returns a new DEEP composition polynomial. Initially, this polynomial will be empty, and
@@ -70,7 +70,7 @@ impl<A: Air, E: FieldElement<BaseField = A::BaseElement>> DeepCompositionPoly<A,
     /// Note that evaluations of T_i(z) and T_i(z * g) are passed in via the `ood_frame` parameter.
     pub fn add_trace_polys(
         &mut self,
-        trace_polys: TracePolyTable<A::BaseElement>,
+        trace_polys: TracePolyTable<A::BaseField>,
         ood_frame: EvaluationFrame<E>,
     ) {
         assert!(self.coefficients.is_empty());
@@ -78,7 +78,7 @@ impl<A: Air, E: FieldElement<BaseField = A::BaseElement>> DeepCompositionPoly<A,
         // compute a second out-of-domain point offset from z by exactly trace generator; this
         // point defines the "next" computation state in relation to point z
         let trace_length = trace_polys.poly_size();
-        let g = E::from(A::BaseElement::get_root_of_unity(log2(trace_length)));
+        let g = E::from(A::BaseField::get_root_of_unity(log2(trace_length)));
         let next_z = self.z * g;
 
         // cache state of registers at points z and z * g
@@ -154,7 +154,7 @@ impl<A: Air, E: FieldElement<BaseField = A::BaseElement>> DeepCompositionPoly<A,
     /// Note that evaluations of H_i(x) at z^m are passed in via the `ood_evaluations` parameter.
     pub fn add_composition_poly(
         &mut self,
-        composition_poly: CompositionPoly<A::BaseElement, E>,
+        composition_poly: CompositionPoly<A::BaseField, E>,
         ood_evaluations: Vec<E>,
     ) {
         assert!(!self.coefficients.is_empty());
@@ -211,7 +211,7 @@ impl<A: Air, E: FieldElement<BaseField = A::BaseElement>> DeepCompositionPoly<A,
     // LOW-DEGREE EXTENSION
     // --------------------------------------------------------------------------------------------
     /// Evaluates DEEP composition polynomial over the specified LDE domain and returns the result.
-    pub fn evaluate(self, domain: &StarkDomain<A::BaseElement>) -> Vec<E> {
+    pub fn evaluate(self, domain: &StarkDomain<A::BaseField>) -> Vec<E> {
         fft::evaluate_poly_with_offset(
             &self.coefficients,
             domain.trace_twiddles(),

--- a/prover/src/constraints/boundary.rs
+++ b/prover/src/constraints/boundary.rs
@@ -29,7 +29,7 @@ pub struct BoundaryConstraintGroup<B: StarkField, E: FieldElement<BaseField = B>
 impl<B: StarkField, E: FieldElement<BaseField = B>> BoundaryConstraintGroup<B, E> {
     /// Creates a new specialized constraint group; twiddles and ce_blowup_factor are passed in for
     /// evaluating large polynomial constraints (if any).
-    pub fn new<A: Air<BaseElement = B>>(
+    pub fn new<A: Air<BaseField = B>>(
         group: air::BoundaryConstraintGroup<B, E>,
         air: &A,
         twiddle_map: &mut BTreeMap<usize, Vec<B>>,

--- a/prover/src/constraints/evaluator.rs
+++ b/prover/src/constraints/evaluator.rs
@@ -29,18 +29,18 @@ const MIN_CONCURRENT_DOMAIN_SIZE: usize = 8192;
 // CONSTRAINT EVALUATOR
 // ================================================================================================
 
-pub struct ConstraintEvaluator<'a, A: Air, E: FieldElement<BaseField = A::BaseElement>> {
+pub struct ConstraintEvaluator<'a, A: Air, E: FieldElement<BaseField = A::BaseField>> {
     air: &'a A,
-    boundary_constraints: Vec<BoundaryConstraintGroup<A::BaseElement, E>>,
+    boundary_constraints: Vec<BoundaryConstraintGroup<A::BaseField, E>>,
     transition_constraints: Vec<TransitionConstraintGroup<E>>,
-    periodic_values: PeriodicValueTable<A::BaseElement>,
-    divisors: Vec<ConstraintDivisor<A::BaseElement>>,
+    periodic_values: PeriodicValueTable<A::BaseField>,
+    divisors: Vec<ConstraintDivisor<A::BaseField>>,
 
     #[cfg(debug_assertions)]
     transition_constraint_degrees: Vec<usize>,
 }
 
-impl<'a, A: Air, E: FieldElement<BaseField = A::BaseElement>> ConstraintEvaluator<'a, A, E> {
+impl<'a, A: Air, E: FieldElement<BaseField = A::BaseField>> ConstraintEvaluator<'a, A, E> {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Returns a new evaluator which can be used to evaluate transition and boundary constraints
@@ -95,9 +95,9 @@ impl<'a, A: Air, E: FieldElement<BaseField = A::BaseElement>> ConstraintEvaluato
     /// evaluation domain can be many times smaller than the full LDE domain.
     pub fn evaluate(
         &self,
-        trace: &TraceLde<A::BaseElement>,
-        domain: &StarkDomain<A::BaseElement>,
-    ) -> ConstraintEvaluationTable<A::BaseElement, E> {
+        trace: &TraceLde<A::BaseField>,
+        domain: &StarkDomain<A::BaseField>,
+    ) -> ConstraintEvaluationTable<A::BaseField, E> {
         assert_eq!(
             trace.len(),
             domain.lde_domain_size(),
@@ -110,7 +110,7 @@ impl<'a, A: Air, E: FieldElement<BaseField = A::BaseElement>> ConstraintEvaluato
         let mut evaluation_table =
             ConstraintEvaluationTable::<A::BaseElement, E>::new(domain, self.divisors.clone());
         #[cfg(debug_assertions)]
-        let mut evaluation_table = ConstraintEvaluationTable::<A::BaseElement, E>::new(
+        let mut evaluation_table = ConstraintEvaluationTable::<A::BaseField, E>::new(
             domain,
             self.divisors.clone(),
             self.transition_constraint_degrees.to_vec(),
@@ -147,14 +147,14 @@ impl<'a, A: Air, E: FieldElement<BaseField = A::BaseElement>> ConstraintEvaluato
     /// Evaluates constraints for a single fragment of the evaluation table.
     fn evaluate_fragment(
         &self,
-        trace: &TraceLde<A::BaseElement>,
-        domain: &StarkDomain<A::BaseElement>,
-        fragment: &mut EvaluationTableFragment<A::BaseElement, E>,
+        trace: &TraceLde<A::BaseField>,
+        domain: &StarkDomain<A::BaseField>,
+        fragment: &mut EvaluationTableFragment<A::BaseField, E>,
     ) {
         // initialize buffers to hold trace values and evaluation results at each step;
         let mut ev_frame = EvaluationFrame::new(trace.width());
         let mut evaluations = vec![E::ZERO; fragment.num_columns()];
-        let mut t_evaluations = vec![A::BaseElement::ZERO; self.air.num_transition_constraints()];
+        let mut t_evaluations = vec![A::BaseField::ZERO; self.air.num_transition_constraints()];
 
         // pre-compute values needed to determine x coordinates in the constraint evaluation domain
         let g = domain.ce_domain_generator();
@@ -200,13 +200,13 @@ impl<'a, A: Air, E: FieldElement<BaseField = A::BaseElement>> ConstraintEvaluato
     /// is the domain offset.
     fn evaluate_transition_constraints(
         &self,
-        frame: &EvaluationFrame<A::BaseElement>,
-        x: A::BaseElement,
+        frame: &EvaluationFrame<A::BaseField>,
+        x: A::BaseField,
         step: usize,
-        evaluations: &mut [A::BaseElement],
+        evaluations: &mut [A::BaseField],
     ) -> E {
         // TODO: use a more efficient way to zero out memory
-        evaluations.fill(A::BaseElement::ZERO);
+        evaluations.fill(A::BaseField::ZERO);
 
         // get periodic values at the evaluation step
         let periodic_values = self.periodic_values.get_row(step);
@@ -230,8 +230,8 @@ impl<'a, A: Air, E: FieldElement<BaseField = A::BaseElement>> ConstraintEvaluato
     /// evaluation domain, and s is the domain offset.
     fn evaluate_boundary_constraints(
         &self,
-        state: &[A::BaseElement],
-        x: A::BaseElement,
+        state: &[A::BaseField],
+        x: A::BaseField,
         step: usize,
         result: &mut [E],
     ) {

--- a/prover/src/constraints/evaluator.rs
+++ b/prover/src/constraints/evaluator.rs
@@ -108,7 +108,7 @@ impl<'a, A: Air, E: FieldElement<BaseField = A::BaseField>> ConstraintEvaluator<
         // single value) so that we can check their degree late
         #[cfg(not(debug_assertions))]
         let mut evaluation_table =
-            ConstraintEvaluationTable::<A::BaseElement, E>::new(domain, self.divisors.clone());
+            ConstraintEvaluationTable::<A::BaseField, E>::new(domain, self.divisors.clone());
         #[cfg(debug_assertions)]
         let mut evaluation_table = ConstraintEvaluationTable::<A::BaseField, E>::new(
             domain,

--- a/prover/src/constraints/evaluator.rs
+++ b/prover/src/constraints/evaluator.rs
@@ -5,7 +5,7 @@
 
 use super::{
     evaluation_table::EvaluationTableFragment, BoundaryConstraintGroup, ConstraintEvaluationTable,
-    PeriodicValueTable, StarkDomain, TraceTable,
+    PeriodicValueTable, StarkDomain, TraceLde,
 };
 use air::{
     Air, ConstraintCompositionCoefficients, ConstraintDivisor, EvaluationFrame,
@@ -95,7 +95,7 @@ impl<'a, A: Air, E: FieldElement<BaseField = A::BaseElement>> ConstraintEvaluato
     /// evaluation domain can be many times smaller than the full LDE domain.
     pub fn evaluate(
         &self,
-        trace: &TraceTable<A::BaseElement>,
+        trace: &TraceLde<A::BaseElement>,
         domain: &StarkDomain<A::BaseElement>,
     ) -> ConstraintEvaluationTable<A::BaseElement, E> {
         assert_eq!(
@@ -147,7 +147,7 @@ impl<'a, A: Air, E: FieldElement<BaseField = A::BaseElement>> ConstraintEvaluato
     /// Evaluates constraints for a single fragment of the evaluation table.
     fn evaluate_fragment(
         &self,
-        trace: &TraceTable<A::BaseElement>,
+        trace: &TraceLde<A::BaseElement>,
         domain: &StarkDomain<A::BaseElement>,
         fragment: &mut EvaluationTableFragment<A::BaseElement, E>,
     ) {

--- a/prover/src/constraints/mod.rs
+++ b/prover/src/constraints/mod.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{trace::TraceTable, ProverError, StarkDomain};
+use super::{trace::TraceLde, ProverError, StarkDomain};
 
 mod boundary;
 use boundary::BoundaryConstraintGroup;

--- a/prover/src/constraints/periodic_table.rs
+++ b/prover/src/constraints/periodic_table.rs
@@ -22,7 +22,7 @@ impl<B: StarkField> PeriodicValueTable<B> {
     /// Builds a table of periodic column values for the specified AIR. The table contains expanded
     /// values of all periodic columns normalized to the same length. This enables simple lookup
     /// into the able using step index of the constraint evaluation domain.
-    pub fn new<A: Air<BaseElement = B>>(air: &A) -> PeriodicValueTable<B> {
+    pub fn new<A: Air<BaseField = B>>(air: &A) -> PeriodicValueTable<B> {
         // get a list of polynomials describing periodic columns from AIR. if there are no
         // periodic columns return an empty table
         let polys = air.get_periodic_column_polys();

--- a/prover/src/domain.rs
+++ b/prover/src/domain.rs
@@ -31,7 +31,7 @@ pub struct StarkDomain<B: StarkField> {
 
 impl<B: StarkField> StarkDomain<B> {
     /// Returns a new STARK domain initialized with the provided `context`.
-    pub fn new<A: Air<BaseElement = B>>(air: &A) -> Self {
+    pub fn new<A: Air<BaseField = B>>(air: &A) -> Self {
         let trace_twiddles = fft::get_twiddles(air.trace_length());
         let ce_twiddles = fft::get_twiddles(air.ce_domain_size());
         StarkDomain {

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -103,8 +103,8 @@ pub mod tests;
 ///    algebraic constraints which define the computation.
 pub trait Prover {
     type BaseField: StarkField + ExtensibleField<2> + ExtensibleField<3>;
-    type Air: Air<BaseElement = Self::BaseField>;
-    type Trace: Trace<Self::BaseField>;
+    type Air: Air<BaseField = Self::BaseField>;
+    type Trace: Trace<BaseField = Self::BaseField>;
 
     // REQUIRED METHODS
     // --------------------------------------------------------------------------------------------
@@ -194,9 +194,9 @@ fn generate_proof<A, T, E, H>(
 ) -> Result<StarkProof, ProverError>
 where
     A: Air,
-    T: Trace<A::BaseElement>,
-    E: FieldElement<BaseField = A::BaseElement>,
-    H: ElementHasher<BaseField = A::BaseElement>,
+    T: Trace<BaseField = A::BaseField>,
+    E: FieldElement<BaseField = A::BaseField>,
+    H: ElementHasher<BaseField = A::BaseField>,
 {
     // create a channel which is used to simulate interaction between the prover and the verifier;
     // the channel will be used to commit to values and to draw randomness that should come from

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -115,6 +115,9 @@ pub trait Prover {
     ///   inform such metrics as proof generation time, proof size, and proof security level.
     fn options(&self) -> &ProofOptions;
 
+    /// TODO: add docs
+    fn get_pub_inputs(&self, trace: &Self::Trace) -> <<Self as Prover>::Air as Air>::PublicInputs;
+
     // PROVIDED METHODS
     // --------------------------------------------------------------------------------------------
 
@@ -131,18 +134,57 @@ pub trait Prover {
     /// trace of the computation described by `Self::AIR` and generated using the specified/ public
     /// inputs.
     #[rustfmt::skip]
-    fn prove(
-        &self,
-        trace: Self::Trace,
-        pub_inputs: <<Self as Prover>::Air as Air>::PublicInputs,
-    ) -> Result<StarkProof, ProverError> {
+    fn prove(&self, trace: Self::Trace) -> Result<StarkProof, ProverError> {
+        // figure out which version of the generic proof generation procedure to run. this is a sort
+        // of static dispatch for selecting two generic parameter: extension field and hash function.
+        match self.options().field_extension() {
+            FieldExtension::None => match self.options().hash_fn() {
+                HashFunction::Blake3_256 => self.generate_proof::<Self::BaseField, Blake3_256<Self::BaseField>>(trace),
+                HashFunction::Blake3_192 => self.generate_proof::<Self::BaseField, Blake3_192<Self::BaseField>>(trace),
+                HashFunction::Sha3_256 => self.generate_proof::<Self::BaseField, Sha3_256<Self::BaseField>>(trace),
+            },
+            FieldExtension::Quadratic => {
+                if !<QuadExtension<Self::BaseField>>::is_supported() {
+                    return Err(ProverError::UnsupportedFieldExtension(2));
+                }
+                match self.options().hash_fn() {
+                    HashFunction::Blake3_256 => self.generate_proof::<QuadExtension<Self::BaseField>, Blake3_256<Self::BaseField>>(trace),
+                    HashFunction::Blake3_192 => self.generate_proof::<QuadExtension<Self::BaseField>, Blake3_192<Self::BaseField>>(trace),
+                    HashFunction::Sha3_256 => self.generate_proof::<QuadExtension<Self::BaseField>, Sha3_256<Self::BaseField>>(trace),
+                }
+            }
+            FieldExtension::Cubic => {
+                if !<CubeExtension<Self::BaseField>>::is_supported() {
+                    return Err(ProverError::UnsupportedFieldExtension(3));
+                }
+                match self.options().hash_fn() {
+                    HashFunction::Blake3_256 => self.generate_proof::<CubeExtension<Self::BaseField>, Blake3_256<Self::BaseField>>(trace),
+                    HashFunction::Blake3_192 => self.generate_proof::<CubeExtension<Self::BaseField>, Blake3_192<Self::BaseField>>(trace),
+                    HashFunction::Sha3_256 => self.generate_proof::<CubeExtension<Self::BaseField>, Sha3_256<Self::BaseField>>(trace),
+                }
+            }
+        }
+    }
+
+    /// Performs the actual proof generation procedure, generating the proof that the provided
+    /// execution `trace` is valid against the provided `air`.
+    /// TODO: make this function un-callable externally?
+    #[doc(hidden)]
+    fn generate_proof<E, H>(&self, trace: Self::Trace) -> Result<StarkProof, ProverError>
+    where
+        E: FieldElement<BaseField = Self::BaseField>,
+        H: ElementHasher<BaseField = Self::BaseField>,
+    {
+        // 0 ----- instantiate AIR and prover channel ---------------------------------------------
+
         // serialize public inputs; these will be included in the seed for the public coin
+        let pub_inputs = self.get_pub_inputs(&trace);
         let mut pub_inputs_bytes = Vec::new();
         pub_inputs.write_into(&mut pub_inputs_bytes);
 
-        // create an instance of AIR for the provided parameters. this takes a generic description of
-        // the computation (provided via AIR type), and creates a description of a specific execution
-        // of the computation for the provided public inputs.
+        // create an instance of AIR for the provided parameters. this takes a generic description
+        // of the computation (provided via AIR type), and creates a description of a specific
+        // execution of the computation for the provided public inputs.
         let air = Self::Air::new(trace.get_info(), pub_inputs, self.options().clone());
 
         // make sure the specified trace is valid against the AIR. This checks validity of both,
@@ -151,77 +193,30 @@ pub trait Prover {
         #[cfg(debug_assertions)]
         trace.validate(&air);
 
-        // figure out which version of the generic proof generation procedure to run. this is a sort
-        // of static dispatch for selecting two generic parameter: extension field and hash function.
-        match air.options().field_extension() {
-            FieldExtension::None => match air.options().hash_fn() {
-                HashFunction::Blake3_256 => generate_proof::<Self::Air, Self::Trace, Self::BaseField, Blake3_256<Self::BaseField>>(air, trace, pub_inputs_bytes),
-                HashFunction::Blake3_192 => generate_proof::<Self::Air, Self::Trace, Self::BaseField, Blake3_192<Self::BaseField>>(air, trace, pub_inputs_bytes),
-                HashFunction::Sha3_256 => generate_proof::<Self::Air, Self::Trace, Self::BaseField, Sha3_256<Self::BaseField>>(air, trace, pub_inputs_bytes),
-            },
-            FieldExtension::Quadratic => {
-                if !<QuadExtension<Self::BaseField>>::is_supported() {
-                    return Err(ProverError::UnsupportedFieldExtension(2));
-                }
-                match air.options().hash_fn() {
-                    HashFunction::Blake3_256 => generate_proof::<Self::Air, Self::Trace, QuadExtension<Self::BaseField>, Blake3_256<Self::BaseField>>(air, trace, pub_inputs_bytes),
-                    HashFunction::Blake3_192 => generate_proof::<Self::Air, Self::Trace, QuadExtension<Self::BaseField>, Blake3_192<Self::BaseField>>(air, trace, pub_inputs_bytes),
-                    HashFunction::Sha3_256 => generate_proof::<Self::Air, Self::Trace, QuadExtension<Self::BaseField>, Sha3_256<Self::BaseField>>(air, trace, pub_inputs_bytes),
-                }
-            }
-            FieldExtension::Cubic => {
-                if !<CubeExtension<Self::BaseField>>::is_supported() {
-                    return Err(ProverError::UnsupportedFieldExtension(3));
-                }
-                match air.options().hash_fn() {
-                    HashFunction::Blake3_256 => generate_proof::<Self::Air, Self::Trace, CubeExtension<Self::BaseField>, Blake3_256<Self::BaseField>>(air, trace, pub_inputs_bytes),
-                    HashFunction::Blake3_192 => generate_proof::<Self::Air, Self::Trace, CubeExtension<Self::BaseField>, Blake3_192<Self::BaseField>>(air, trace, pub_inputs_bytes),
-                    HashFunction::Sha3_256 => generate_proof::<Self::Air, Self::Trace, CubeExtension<Self::BaseField>, Sha3_256<Self::BaseField>>(air, trace, pub_inputs_bytes),
-                }
-            }
-        }
-    }
-}
+        // create a channel which is used to simulate interaction between the prover and the
+        // verifier; the channel will be used to commit to values and to draw randomness that
+        // should come from the verifier.
+        let mut channel = ProverChannel::<Self::Air, E, H>::new(&air, pub_inputs_bytes);
 
-// PROOF GENERATION PROCEDURE
-// ================================================================================================
-/// Performs the actual proof generation procedure, generating the proof that the provided
-/// execution `trace` is valid against the provided `air`.
-fn generate_proof<A, T, E, H>(
-    air: A,
-    trace: T,
-    pub_inputs_bytes: Vec<u8>,
-) -> Result<StarkProof, ProverError>
-where
-    A: Air,
-    T: Trace<BaseField = A::BaseField>,
-    E: FieldElement<BaseField = A::BaseField>,
-    H: ElementHasher<BaseField = A::BaseField>,
-{
-    // create a channel which is used to simulate interaction between the prover and the verifier;
-    // the channel will be used to commit to values and to draw randomness that should come from
-    // the verifier.
-    let mut channel = ProverChannel::<A, E, H>::new(&air, pub_inputs_bytes);
+        // 1 ----- extend execution trace ---------------------------------------------------------
 
-    // 1 ----- extend execution trace -------------------------------------------------------------
+        // build computation domain; this is used later for polynomial evaluations
+        #[cfg(feature = "std")]
+        let now = Instant::now();
+        let domain = StarkDomain::new(&air);
+        #[cfg(feature = "std")]
+        debug!(
+            "Built domain of 2^{} elements in {} ms",
+            log2(domain.lde_domain_size()),
+            now.elapsed().as_millis()
+        );
 
-    // build computation domain; this is used later for polynomial evaluations
-    #[cfg(feature = "std")]
-    let now = Instant::now();
-    let domain = StarkDomain::new(&air);
-    #[cfg(feature = "std")]
-    debug!(
-        "Built domain of 2^{} elements in {} ms",
-        log2(domain.lde_domain_size()),
-        now.elapsed().as_millis()
-    );
-
-    // extend the execution trace; this interpolates each register of the trace into a polynomial,
-    // and then evaluates the polynomial over the LDE domain; each of the trace polynomials has
-    // degree = trace_length - 1
-    let (extended_trace, trace_polys) = trace.extend(&domain);
-    #[cfg(feature = "std")]
-    debug!(
+        // extend the execution trace; this interpolates each register of the trace into a
+        // polynomial, and then evaluates the polynomial over the LDE domain; each of the trace
+        // polynomials has degree = trace_length - 1
+        let (extended_trace, trace_polys) = trace.extend(&domain);
+        #[cfg(feature = "std")]
+        debug!(
         "Extended execution trace of {} registers from 2^{} to 2^{} steps ({}x blowup) in {} ms",
         extended_trace.width(),
         log2(trace_polys.poly_size()),
@@ -230,190 +225,194 @@ where
         now.elapsed().as_millis()
     );
 
-    // 2 ----- commit to the extended execution trace ---------------------------------------------
-    #[cfg(feature = "std")]
-    let now = Instant::now();
-    let trace_tree = extended_trace.build_commitment::<H>();
-    channel.commit_trace(*trace_tree.root());
-    #[cfg(feature = "std")]
-    debug!(
-        "Committed to extended execution trace by building a Merkle tree of depth {} in {} ms",
-        trace_tree.depth(),
-        now.elapsed().as_millis()
-    );
+        // 2 ----- commit to the extended execution trace -----------------------------------------
+        #[cfg(feature = "std")]
+        let now = Instant::now();
+        let trace_tree = extended_trace.build_commitment::<H>();
+        channel.commit_trace(*trace_tree.root());
+        #[cfg(feature = "std")]
+        debug!(
+            "Committed to extended execution trace by building a Merkle tree of depth {} in {} ms",
+            trace_tree.depth(),
+            now.elapsed().as_millis()
+        );
 
-    // 3 ----- evaluate constraints ---------------------------------------------------------------
-    // evaluate constraints specified by the AIR over the constraint evaluation domain, and compute
-    // random linear combinations of these evaluations using coefficients drawn from the channel;
-    // this step evaluates only constraint numerators, thus, only constraints with identical
-    // denominators are merged together. the results are saved into a constraint evaluation table
-    // where each column contains merged evaluations of constraints with identical denominators.
-    #[cfg(feature = "std")]
-    let now = Instant::now();
-    let constraint_coeffs = channel.get_constraint_composition_coeffs();
-    let evaluator = ConstraintEvaluator::new(&air, constraint_coeffs);
-    let constraint_evaluations = evaluator.evaluate(&extended_trace, &domain);
-    #[cfg(feature = "std")]
-    debug!(
-        "Evaluated constraints over domain of 2^{} elements in {} ms",
-        log2(constraint_evaluations.num_rows()),
-        now.elapsed().as_millis()
-    );
+        // 3 ----- evaluate constraints -----------------------------------------------------------
+        // evaluate constraints specified by the AIR over the constraint evaluation domain, and
+        // compute random linear combinations of these evaluations using coefficients drawn from
+        // the channel; this step evaluates only constraint numerators, thus, only constraints with
+        // identical denominators are merged together. the results are saved into a constraint
+        // evaluation table where each column contains merged evaluations of constraints with
+        // identical denominators.
+        #[cfg(feature = "std")]
+        let now = Instant::now();
+        let constraint_coeffs = channel.get_constraint_composition_coeffs();
+        let evaluator = ConstraintEvaluator::new(&air, constraint_coeffs);
+        let constraint_evaluations = evaluator.evaluate(&extended_trace, &domain);
+        #[cfg(feature = "std")]
+        debug!(
+            "Evaluated constraints over domain of 2^{} elements in {} ms",
+            log2(constraint_evaluations.num_rows()),
+            now.elapsed().as_millis()
+        );
 
-    // 4 ----- commit to constraint evaluations ---------------------------------------------------
+        // 4 ----- commit to constraint evaluations -----------------------------------------------
 
-    // first, build constraint composition polynomial from the constraint evaluation table:
-    // - divide all constraint evaluation columns by their respective divisors
-    // - combine them into a single column of evaluations,
-    // - interpolate the column into a polynomial in coefficient form
-    // - "break" the polynomial into a set of column polynomials each of degree equal to
-    //   trace_length - 1
-    #[cfg(feature = "std")]
-    let now = Instant::now();
-    let composition_poly = constraint_evaluations.into_poly()?;
-    #[cfg(feature = "std")]
-    debug!(
+        // first, build constraint composition polynomial from the constraint evaluation table:
+        // - divide all constraint evaluation columns by their respective divisors
+        // - combine them into a single column of evaluations,
+        // - interpolate the column into a polynomial in coefficient form
+        // - "break" the polynomial into a set of column polynomials each of degree equal to
+        //   trace_length - 1
+        #[cfg(feature = "std")]
+        let now = Instant::now();
+        let composition_poly = constraint_evaluations.into_poly()?;
+        #[cfg(feature = "std")]
+        debug!(
         "Converted constraint evaluations into {} composition polynomial columns of degree {} in {} ms",
         composition_poly.num_columns(),
         composition_poly.column_degree(),
         now.elapsed().as_millis()
     );
 
-    // then, evaluate composition polynomial columns over the LDE domain
-    #[cfg(feature = "std")]
-    let now = Instant::now();
-    let composed_evaluations = composition_poly.evaluate(&domain);
-    #[cfg(feature = "std")]
-    debug!(
-        "Evaluated composition polynomial columns over LDE domain (2^{} elements) in {} ms",
-        log2(composed_evaluations[0].len()),
-        now.elapsed().as_millis()
-    );
+        // then, evaluate composition polynomial columns over the LDE domain
+        #[cfg(feature = "std")]
+        let now = Instant::now();
+        let composed_evaluations = composition_poly.evaluate(&domain);
+        #[cfg(feature = "std")]
+        debug!(
+            "Evaluated composition polynomial columns over LDE domain (2^{} elements) in {} ms",
+            log2(composed_evaluations[0].len()),
+            now.elapsed().as_millis()
+        );
 
-    // finally, commit to the composition polynomial evaluations
-    #[cfg(feature = "std")]
-    let now = Instant::now();
-    let constraint_commitment = ConstraintCommitment::<E, H>::new(composed_evaluations);
-    channel.commit_constraints(constraint_commitment.root());
-    #[cfg(feature = "std")]
-    debug!(
-        "Committed to composed evaluations by building a Merkle tree of depth {} in {} ms",
-        constraint_commitment.tree_depth(),
-        now.elapsed().as_millis()
-    );
+        // finally, commit to the composition polynomial evaluations
+        #[cfg(feature = "std")]
+        let now = Instant::now();
+        let constraint_commitment = ConstraintCommitment::<E, H>::new(composed_evaluations);
+        channel.commit_constraints(constraint_commitment.root());
+        #[cfg(feature = "std")]
+        debug!(
+            "Committed to composed evaluations by building a Merkle tree of depth {} in {} ms",
+            constraint_commitment.tree_depth(),
+            now.elapsed().as_millis()
+        );
 
-    // 5 ----- build DEEP composition polynomial --------------------------------------------------
-    #[cfg(feature = "std")]
-    let now = Instant::now();
+        // 5 ----- build DEEP composition polynomial ----------------------------------------------
+        #[cfg(feature = "std")]
+        let now = Instant::now();
 
-    // draw an out-of-domain point z. Depending on the type of E, the point is drawn either
-    // from the base field or from an extension field defined by E.
-    //
-    // The purpose of sampling from the extension field here (instead of the base field) is to
-    // increase security. Soundness is limited by the size of the field that the random point
-    // is drawn from, and we can potentially save on performance by only drawing this point
-    // from an extension field, rather than increasing the size of the field overall.
-    let z = channel.get_ood_point();
+        // draw an out-of-domain point z. Depending on the type of E, the point is drawn either
+        // from the base field or from an extension field defined by E.
+        //
+        // The purpose of sampling from the extension field here (instead of the base field) is to
+        // increase security. Soundness is limited by the size of the field that the random point
+        // is drawn from, and we can potentially save on performance by only drawing this point
+        // from an extension field, rather than increasing the size of the field overall.
+        let z = channel.get_ood_point();
 
-    // evaluate trace and constraint polynomials at the OOD point z, and send the results to
-    // the verifier. the trace polynomials are actually evaluated over two points: z and z * g,
-    // where g is the generator of the trace domain.
-    let ood_frame = trace_polys.get_ood_frame(z);
-    channel.send_ood_evaluation_frame(&ood_frame);
+        // evaluate trace and constraint polynomials at the OOD point z, and send the results to
+        // the verifier. the trace polynomials are actually evaluated over two points: z and z * g,
+        // where g is the generator of the trace domain.
+        let ood_frame = trace_polys.get_ood_frame(z);
+        channel.send_ood_evaluation_frame(&ood_frame);
 
-    let ood_evaluations = composition_poly.evaluate_at(z);
-    channel.send_ood_constraint_evaluations(&ood_evaluations);
+        let ood_evaluations = composition_poly.evaluate_at(z);
+        channel.send_ood_constraint_evaluations(&ood_evaluations);
 
-    // draw random coefficients to use during DEEP polynomial composition, and use them to
-    // initialize the DEEP composition polynomial
-    let deep_coefficients = channel.get_deep_composition_coeffs();
-    let mut deep_composition_poly = DeepCompositionPoly::new(&air, z, deep_coefficients);
+        // draw random coefficients to use during DEEP polynomial composition, and use them to
+        // initialize the DEEP composition polynomial
+        let deep_coefficients = channel.get_deep_composition_coeffs();
+        let mut deep_composition_poly = DeepCompositionPoly::new(&air, z, deep_coefficients);
 
-    // combine all trace polynomials together and merge them into the DEEP composition polynomial
-    deep_composition_poly.add_trace_polys(trace_polys, ood_frame);
+        // combine all trace polynomials together and merge them into the DEEP composition
+        // polynomial
+        deep_composition_poly.add_trace_polys(trace_polys, ood_frame);
 
-    // merge columns of constraint composition polynomial into the DEEP composition polynomial;
-    deep_composition_poly.add_composition_poly(composition_poly, ood_evaluations);
+        // merge columns of constraint composition polynomial into the DEEP composition polynomial;
+        deep_composition_poly.add_composition_poly(composition_poly, ood_evaluations);
 
-    // raise the degree of the DEEP composition polynomial by one to make sure it is equal to
-    // trace_length - 1
-    deep_composition_poly.adjust_degree();
+        // raise the degree of the DEEP composition polynomial by one to make sure it is equal to
+        // trace_length - 1
+        deep_composition_poly.adjust_degree();
 
-    #[cfg(feature = "std")]
-    debug!(
-        "Built DEEP composition polynomial of degree {} in {} ms",
-        deep_composition_poly.degree(),
-        now.elapsed().as_millis()
-    );
+        #[cfg(feature = "std")]
+        debug!(
+            "Built DEEP composition polynomial of degree {} in {} ms",
+            deep_composition_poly.degree(),
+            now.elapsed().as_millis()
+        );
 
-    // make sure the degree of the DEEP composition polynomial is equal to trace polynomial degree
-    assert_eq!(domain.trace_length() - 1, deep_composition_poly.degree());
+        // make sure the degree of the DEEP composition polynomial is equal to trace polynomial
+        // degree
+        assert_eq!(domain.trace_length() - 1, deep_composition_poly.degree());
 
-    // 6 ----- evaluate DEEP composition polynomial over LDE domain -------------------------------
-    #[cfg(feature = "std")]
-    let now = Instant::now();
-    let deep_evaluations = deep_composition_poly.evaluate(&domain);
-    // we check the following condition in debug mode only because infer_degree is an expensive
-    // operation
-    debug_assert_eq!(
-        domain.trace_length() - 1,
-        infer_degree(&deep_evaluations, domain.offset())
-    );
-    #[cfg(feature = "std")]
-    debug!(
-        "Evaluated DEEP composition polynomial over LDE domain (2^{} elements) in {} ms",
-        log2(domain.lde_domain_size()),
-        now.elapsed().as_millis()
-    );
+        // 6 ----- evaluate DEEP composition polynomial over LDE domain ---------------------------
+        #[cfg(feature = "std")]
+        let now = Instant::now();
+        let deep_evaluations = deep_composition_poly.evaluate(&domain);
+        // we check the following condition in debug mode only because infer_degree is an expensive
+        // operation
+        debug_assert_eq!(
+            domain.trace_length() - 1,
+            infer_degree(&deep_evaluations, domain.offset())
+        );
+        #[cfg(feature = "std")]
+        debug!(
+            "Evaluated DEEP composition polynomial over LDE domain (2^{} elements) in {} ms",
+            log2(domain.lde_domain_size()),
+            now.elapsed().as_millis()
+        );
 
-    // 7 ----- compute FRI layers for the composition polynomial ----------------------------------
-    #[cfg(feature = "std")]
-    let now = Instant::now();
-    let mut fri_prover = FriProver::new(air.options().to_fri_options());
-    fri_prover.build_layers(&mut channel, deep_evaluations);
-    #[cfg(feature = "std")]
-    debug!(
-        "Computed {} FRI layers from composition polynomial evaluations in {} ms",
-        fri_prover.num_layers(),
-        now.elapsed().as_millis()
-    );
+        // 7 ----- compute FRI layers for the composition polynomial ------------------------------
+        #[cfg(feature = "std")]
+        let now = Instant::now();
+        let mut fri_prover = FriProver::new(air.options().to_fri_options());
+        fri_prover.build_layers(&mut channel, deep_evaluations);
+        #[cfg(feature = "std")]
+        debug!(
+            "Computed {} FRI layers from composition polynomial evaluations in {} ms",
+            fri_prover.num_layers(),
+            now.elapsed().as_millis()
+        );
 
-    // 8 ----- determine query positions ----------------------------------------------------------
-    #[cfg(feature = "std")]
-    let now = Instant::now();
+        // 8 ----- determine query positions ------------------------------------------------------
+        #[cfg(feature = "std")]
+        let now = Instant::now();
 
-    // apply proof-of-work to the query seed
-    channel.grind_query_seed();
+        // apply proof-of-work to the query seed
+        channel.grind_query_seed();
 
-    // generate pseudo-random query positions
-    let query_positions = channel.get_query_positions();
-    #[cfg(feature = "std")]
-    debug!(
-        "Determined {} query positions in {} ms",
-        query_positions.len(),
-        now.elapsed().as_millis()
-    );
+        // generate pseudo-random query positions
+        let query_positions = channel.get_query_positions();
+        #[cfg(feature = "std")]
+        debug!(
+            "Determined {} query positions in {} ms",
+            query_positions.len(),
+            now.elapsed().as_millis()
+        );
 
-    // 9 ----- build proof object -----------------------------------------------------------------
-    #[cfg(feature = "std")]
-    let now = Instant::now();
+        // 9 ----- build proof object -------------------------------------------------------------
+        #[cfg(feature = "std")]
+        let now = Instant::now();
 
-    // generate FRI proof
-    let fri_proof = fri_prover.build_proof(&query_positions);
+        // generate FRI proof
+        let fri_proof = fri_prover.build_proof(&query_positions);
 
-    // query the execution trace at the selected position; for each query, we need the
-    // state of the trace at that position + Merkle authentication path
-    let trace_queries = extended_trace.query(trace_tree, &query_positions);
+        // query the execution trace at the selected position; for each query, we need the
+        // state of the trace at that position + Merkle authentication path
+        let trace_queries = extended_trace.query(trace_tree, &query_positions);
 
-    // query the constraint commitment at the selected positions; for each query, we need just
-    // a Merkle authentication path. this is because constraint evaluations for each step are
-    // merged into a single value and Merkle authentication paths contain these values already
-    let constraint_queries = constraint_commitment.query(&query_positions);
+        // query the constraint commitment at the selected positions; for each query, we need just
+        // a Merkle authentication path. this is because constraint evaluations for each step are
+        // merged into a single value and Merkle authentication paths contain these values already
+        let constraint_queries = constraint_commitment.query(&query_positions);
 
-    // build the proof object
-    let proof = channel.build_proof(trace_queries, constraint_queries, fri_proof);
-    #[cfg(feature = "std")]
-    debug!("Built proof object in {} ms", now.elapsed().as_millis());
+        // build the proof object
+        let proof = channel.build_proof(trace_queries, constraint_queries, fri_proof);
+        #[cfg(feature = "std")]
+        debug!("Built proof object in {} ms", now.elapsed().as_millis());
 
-    Ok(proof)
+        Ok(proof)
+    }
 }

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -84,7 +84,7 @@ use composer::DeepCompositionPoly;
 
 mod trace;
 use trace::TracePolyTable;
-pub use trace::{ExecutionTrace, ExecutionTraceFragment, Trace};
+pub use trace::{Trace, TraceTable, TraceTableFragment};
 
 mod channel;
 use channel::ProverChannel;

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -95,7 +95,7 @@ impl MockAir {
 }
 
 impl Air for MockAir {
-    type BaseElement = BaseElement;
+    type BaseField = BaseElement;
     type PublicInputs = ();
 
     fn new(trace_info: TraceInfo, _pub_inputs: (), _options: ProofOptions) -> Self {
@@ -107,11 +107,11 @@ impl Air for MockAir {
         }
     }
 
-    fn context(&self) -> &AirContext<Self::BaseElement> {
+    fn context(&self) -> &AirContext<Self::BaseField> {
         &self.context
     }
 
-    fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
         _frame: &EvaluationFrame<E>,
         _periodic_values: &[E],
@@ -119,11 +119,11 @@ impl Air for MockAir {
     ) {
     }
 
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
         self.assertions.clone()
     }
 
-    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseElement>> {
+    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseField>> {
         self.periodic_columns.clone()
     }
 }

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use crate::ExecutionTrace;
+use crate::TraceTable;
 use air::{
     Air, AirContext, Assertion, EvaluationFrame, FieldExtension, HashFunction, ProofOptions,
     TraceInfo, TransitionConstraintDegree,
@@ -14,7 +14,7 @@ use utils::collections::Vec;
 // FIBONACCI TRACE BUILDER
 // ================================================================================================
 
-pub fn build_fib_trace(length: usize) -> ExecutionTrace<BaseElement> {
+pub fn build_fib_trace(length: usize) -> TraceTable<BaseElement> {
     assert!(length.is_power_of_two(), "length must be a power of 2");
 
     let mut reg1 = vec![BaseElement::ONE];
@@ -25,7 +25,7 @@ pub fn build_fib_trace(length: usize) -> ExecutionTrace<BaseElement> {
         reg2.push(reg1[i] + BaseElement::from(2u8) * reg2[i]);
     }
 
-    ExecutionTrace::init(vec![reg1, reg2])
+    TraceTable::init(vec![reg1, reg2])
 }
 
 // MOCK AIR

--- a/prover/src/trace/execution_trace.rs
+++ b/prover/src/trace/execution_trace.rs
@@ -334,7 +334,9 @@ impl<B: StarkField> ExecutionTrace<B> {
     }
 }
 
-impl<B: StarkField> Trace<B> for ExecutionTrace<B> {
+impl<B: StarkField> Trace for ExecutionTrace<B> {
+    type BaseField = B;
+
     fn meta(&self) -> &[u8] {
         &self.meta
     }

--- a/prover/src/trace/mod.rs
+++ b/prover/src/trace/mod.rs
@@ -13,8 +13,8 @@ pub use trace_lde::TraceLde;
 mod poly_table;
 pub use poly_table::TracePolyTable;
 
-mod execution_trace;
-pub use execution_trace::{ExecutionTrace, ExecutionTraceFragment};
+mod trace_table;
+pub use trace_table::{TraceTable, TraceTableFragment};
 
 use utils::{collections::Vec, iter_mut};
 

--- a/prover/src/trace/mod.rs
+++ b/prover/src/trace/mod.rs
@@ -5,10 +5,10 @@
 
 use super::StarkDomain;
 
-mod trace_table;
+mod trace_lde;
 use air::{Air, EvaluationFrame, TraceInfo};
 use math::{fft, polynom, StarkField};
-pub use trace_table::TraceTable;
+pub use trace_lde::TraceLde;
 
 mod poly_table;
 pub use poly_table::TracePolyTable;
@@ -136,7 +136,7 @@ pub trait Trace<B: StarkField>: Sized {
     ///
     /// The extension is done by first interpolating each register into a polynomial over the
     /// trace domain, and then evaluating the polynomial over the LDE domain.
-    fn extend(self, domain: &StarkDomain<B>) -> (TraceTable<B>, TracePolyTable<B>) {
+    fn extend(self, domain: &StarkDomain<B>) -> (TraceLde<B>, TracePolyTable<B>) {
         assert_eq!(
             self.length(),
             domain.trace_length(),
@@ -155,7 +155,7 @@ pub trait Trace<B: StarkField>: Sized {
             .collect();
 
         (
-            TraceTable::new(extended_trace, domain.trace_to_lde_blowup()),
+            TraceLde::new(extended_trace, domain.trace_to_lde_blowup()),
             TracePolyTable::new(columns),
         )
     }

--- a/prover/src/trace/mod.rs
+++ b/prover/src/trace/mod.rs
@@ -4,10 +4,10 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::StarkDomain;
-
-mod trace_lde;
 use air::{Air, EvaluationFrame, TraceInfo};
 use math::{fft, polynom, FieldElement, StarkField};
+
+mod trace_lde;
 pub use trace_lde::TraceLde;
 
 mod poly_table;
@@ -26,15 +26,30 @@ mod tests;
 
 // TRACE TRAIT
 // ================================================================================================
-
-// TODO: add docs
+/// Defines an execution trace of a computation.
+///
+/// Execution trace can be reduced to a two-dimensional matrix in which each row represents the
+/// state of a computation at a single point in time and each column corresponds to an algebraic
+/// register tracked over all steps of the computation.
+///
+/// Building a trace is required for STARK proof generation. An execution trace of a specific
+/// instance of a computation must be supplied to [Prover::prove()](super::Prover::prove) method
+/// to generate a STARK proof.
+///
+/// This crate exposes one concrete implementation of the [Trace] trait: [TraceTable]. This
+/// implementation supports concurrent trace generation and should be sufficient in most
+/// situations. However, if functionality provided by [TraceTable] is not sufficient, uses can
+/// provide custom implementations of the [Trace] trait which better suit their needs.
 pub trait Trace: Sized {
+    /// Base field for this execution trace.
+    ///
+    /// All cells of this execution trace contain values which are elements in this filed.
     type BaseField: StarkField;
 
     // REQUIRED METHODS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns number of columns in the trace.
+    /// Returns number of columns in this trace.
     fn width(&self) -> usize;
 
     /// Returns the number of rows in this trace.
@@ -43,7 +58,7 @@ pub trait Trace: Sized {
     /// Returns metadata associated with this trace.
     fn meta(&self) -> &[u8];
 
-    /// Returns value of the cell in the specified column at the specified row.
+    /// Returns value of the cell in the specified column at the specified row of this trace.
     fn get(&self, col_idx: usize, row_idx: usize) -> Self::BaseField;
 
     /// Reads a single row of this trace at the specified index into the specified target.

--- a/prover/src/trace/mod.rs
+++ b/prover/src/trace/mod.rs
@@ -6,6 +6,8 @@
 use super::StarkDomain;
 
 mod trace_table;
+use air::{Air, EvaluationFrame, TraceInfo};
+use math::{fft, polynom, StarkField};
 pub use trace_table::TraceTable;
 
 mod poly_table;
@@ -14,5 +16,168 @@ pub use poly_table::TracePolyTable;
 mod execution_trace;
 pub use execution_trace::{ExecutionTrace, ExecutionTraceFragment};
 
+use utils::{collections::Vec, iter_mut};
+
+#[cfg(feature = "concurrent")]
+use utils::iterators::*;
+
 #[cfg(test)]
 mod tests;
+
+// TRACE TRAIT
+// ================================================================================================
+
+// TODO: add docs
+pub trait Trace<B: StarkField>: Sized {
+    // REQUIRED METHODS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns number of columns in the trace.
+    fn width(&self) -> usize;
+
+    /// Returns the number of rows in this trace.
+    fn length(&self) -> usize;
+
+    /// Returns metadata associated with this trace.
+    fn meta(&self) -> &[u8];
+
+    /// Returns value of the cell in the specified column at the specified row.
+    fn get(&self, col_idx: usize, row_idx: usize) -> B;
+
+    /// Reads a single row of this trace at the specified index into the specified target.
+    fn read_row_into(&self, step: usize, target: &mut [B]);
+
+    /// Transforms this trace into a vector of columns containing trace data.
+    fn into_columns(self) -> Vec<Vec<B>>;
+
+    // PROVIDED METHODS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns trace info for this trace.
+    fn get_info(&self) -> TraceInfo {
+        TraceInfo::with_meta(self.width(), self.length(), self.meta().to_vec())
+    }
+
+    // VALIDATION
+    // --------------------------------------------------------------------------------------------
+    /// Checks if this trace is valid against the specified AIR, and panics if not.
+    ///
+    /// NOTE: this is a very expensive operation and is intended for use only in debug mode.
+    fn validate<A: Air<BaseElement = B>>(&self, air: &A) {
+        // TODO: eventually, this should return errors instead of panicking
+
+        // make sure the width align; if they don't something went terribly wrong
+        assert_eq!(
+            self.width(),
+            air.trace_width(),
+            "inconsistent trace width: expected {}, but was {}",
+            self.width(),
+            air.trace_width()
+        );
+
+        // --- 1. make sure the assertions are valid ----------------------------------------------
+        for assertion in air.get_assertions() {
+            assertion.apply(self.length(), |step, value| {
+                assert!(
+                    value == self.get(assertion.register(), step),
+                    "trace does not satisfy assertion trace({}, {}) == {}",
+                    assertion.register(),
+                    step,
+                    value
+                );
+            });
+        }
+
+        // --- 2. make sure this trace satisfies all transition constraints -----------------------
+
+        // collect the info needed to build periodic values for a specific step
+        let g = air.trace_domain_generator();
+        let periodic_values_polys = air.get_periodic_column_polys();
+        let mut periodic_values = vec![B::ZERO; periodic_values_polys.len()];
+
+        // initialize buffers to hold evaluation frames and results of constraint evaluations
+        let mut x = B::ONE;
+        let mut ev_frame = EvaluationFrame::new(self.width());
+        let mut evaluations = vec![B::ZERO; air.num_transition_constraints()];
+
+        for step in 0..self.length() - 1 {
+            // build periodic values
+            for (p, v) in periodic_values_polys.iter().zip(periodic_values.iter_mut()) {
+                let num_cycles = air.trace_length() / p.len();
+                let x = x.exp((num_cycles as u32).into());
+                *v = polynom::eval(p, x);
+            }
+
+            // build evaluation frame
+            self.read_row_into(step, ev_frame.current_mut());
+            self.read_row_into(step + 1, ev_frame.next_mut());
+
+            // evaluate transition constraints
+            air.evaluate_transition(&ev_frame, &periodic_values, &mut evaluations);
+
+            // make sure all constraints evaluated to ZERO
+            for (i, &evaluation) in evaluations.iter().enumerate() {
+                assert!(
+                    evaluation == B::ZERO,
+                    "transition constraint {} did not evaluate to ZERO at step {}",
+                    i,
+                    step
+                );
+            }
+
+            // update x coordinate of the domain
+            x *= g;
+        }
+    }
+
+    // LOW-DEGREE EXTENSION
+    // --------------------------------------------------------------------------------------------
+    /// Extends all columns of the trace table to the length of the LDE domain.
+    ///
+    /// The extension is done by first interpolating each register into a polynomial over the
+    /// trace domain, and then evaluating the polynomial over the LDE domain.
+    fn extend(self, domain: &StarkDomain<B>) -> (TraceTable<B>, TracePolyTable<B>) {
+        assert_eq!(
+            self.length(),
+            domain.trace_length(),
+            "inconsistent trace length"
+        );
+        // build and cache trace twiddles for FFT interpolation; we do it here so that we
+        // don't have to rebuild these twiddles for every register.
+        let inv_twiddles = fft::get_inv_twiddles::<B>(domain.trace_length());
+
+        // extend all registers; the extension procedure first interpolates register traces into
+        // polynomials (in-place), then evaluates these polynomials over a larger domain, and
+        // then returns extended evaluations.
+        let mut columns = self.into_columns();
+        let extended_trace = iter_mut!(columns)
+            .map(|register_trace| extend_column(register_trace, domain, &inv_twiddles))
+            .collect();
+
+        (
+            TraceTable::new(extended_trace, domain.trace_to_lde_blowup()),
+            TracePolyTable::new(columns),
+        )
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+#[inline(always)]
+fn extend_column<B: StarkField>(
+    column: &mut [B],
+    domain: &StarkDomain<B>,
+    inv_twiddles: &[B],
+) -> Vec<B> {
+    let domain_offset = domain.offset();
+    let twiddles = domain.trace_twiddles();
+    let blowup_factor = domain.trace_to_lde_blowup();
+
+    // interpolate register trace into a polynomial; we do this over the un-shifted trace_domain
+    fft::interpolate_poly(column, inv_twiddles);
+
+    // evaluate the polynomial over extended domain; the domain may be shifted by the
+    // domain_offset
+    fft::evaluate_poly_with_offset(column, twiddles, domain_offset, blowup_factor)
+}

--- a/prover/src/trace/tests.rs
+++ b/prover/src/trace/tests.rs
@@ -72,11 +72,11 @@ fn extend_trace_table() {
     let lde_domain = build_lde_domain(domain.lde_domain_size());
     assert_eq!(
         trace_polys.get_poly(0),
-        polynom::interpolate(&lde_domain, extended_trace.get_register(0), true)
+        polynom::interpolate(&lde_domain, extended_trace.get_column(0), true)
     );
     assert_eq!(
         trace_polys.get_poly(1),
-        polynom::interpolate(&lde_domain, extended_trace.get_register(1), true)
+        polynom::interpolate(&lde_domain, extended_trace.get_column(1), true)
     );
 }
 

--- a/prover/src/trace/tests.rs
+++ b/prover/src/trace/tests.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     tests::{build_fib_trace, MockAir},
-    StarkDomain,
+    StarkDomain, Trace,
 };
 use crypto::{hashers::Blake3_256, ElementHasher, MerkleTree};
 use math::{

--- a/prover/src/trace/trace_lde.rs
+++ b/prover/src/trace/trace_lde.rs
@@ -11,55 +11,57 @@ use utils::{batch_iter_mut, collections::Vec, uninit_vector};
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;
 
-// TRACE TABLE
+// TRACE LDE
 // ================================================================================================
-pub struct TraceTable<B: StarkField> {
+
+/// Trace low-degree extension.
+pub struct TraceLde<B: StarkField> {
     data: Vec<Vec<B>>,
     blowup: usize,
 }
 
-impl<B: StarkField> TraceTable<B> {
+impl<B: StarkField> TraceLde<B> {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
-    /// Creates a new trace table from a list of provided register traces.
+    /// Creates a new trace low-degree extension from a list of provided columns.
     pub(super) fn new(data: Vec<Vec<B>>, blowup: usize) -> Self {
-        TraceTable { data, blowup }
+        TraceLde { data, blowup }
     }
 
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns number of registers in the trace table.
+    /// Returns number of columns in this trace LDE.
     pub fn width(&self) -> usize {
         self.data.len()
     }
 
-    /// Returns the number of states in this trace table.
+    /// Returns the number of rows in this trace LDE.
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.data[0].len()
     }
 
-    /// Returns blowup factor which was used to extend original trace into this trace.
+    /// Returns blowup factor which was used to extend original execution trace into this LDE.
     pub fn blowup(&self) -> usize {
         self.blowup
     }
 
-    /// Returns value in the specified `register` at the specified `step`.
-    pub fn get(&self, register: usize, step: usize) -> B {
-        self.data[register][step]
+    /// Returns value of a trace cell in the column at the specified index at the specified step.
+    pub fn get(&self, col_idx: usize, step: usize) -> B {
+        self.data[col_idx][step]
     }
 
-    /// Returns the entire register trace for the register at the specified index.
+    /// Returns the entire trace for the column at the specified index.
     #[cfg(test)]
-    pub fn get_register(&self, idx: usize) -> &[B] {
-        &self.data[idx]
+    pub fn get_column(&self, col_idx: usize) -> &[B] {
+        &self.data[col_idx]
     }
 
-    /// Copies values of all registers at the specified `step` into the `destination` slice.
+    /// Copies values of all columns at the specified `step` into the `destination` slice.
     pub fn read_row_into(&self, step: usize, row: &mut [B]) {
-        for (register, value) in self.data.iter().zip(row.iter_mut()) {
-            *value = register[step];
+        for (column, value) in self.data.iter().zip(row.iter_mut()) {
+            *value = column[step];
         }
     }
 

--- a/prover/src/trace/trace_table.rs
+++ b/prover/src/trace/trace_table.rs
@@ -21,13 +21,10 @@ const MIN_FRAGMENT_LENGTH: usize = 2;
 
 // TRACE TABLE
 // ================================================================================================
-/// An execution trace of a computation.
+/// A concrete implementation of the [Trace] trait.
 ///
-/// Execution trace is a two-dimensional matrix in which each row represents the state of a
-/// computation at a single point in time and each column corresponds to an algebraic register
-/// tracked over all steps of the computation.
-///
-/// There are two ways to create an execution trace.
+/// This implementation supports concurrent trace generation and should be sufficient for most use
+/// cases. There are two ways to create a trace table trace.
 ///
 /// First, you can use the [TraceTable::init()] function which takes a set of vectors as a
 /// parameter, where each vector contains values for a given column of the trace. This approach
@@ -331,11 +328,26 @@ impl<B: StarkField> TraceTable<B> {
     }
 }
 
+// TRACE TRAIT IMPLEMENTATION
+// ================================================================================================
+
 impl<B: StarkField> Trace for TraceTable<B> {
     type BaseField = B;
 
+    fn width(&self) -> usize {
+        self.trace.len()
+    }
+
+    fn length(&self) -> usize {
+        self.trace[0].len()
+    }
+
     fn meta(&self) -> &[u8] {
         &self.meta
+    }
+
+    fn get(&self, register: usize, step: usize) -> B {
+        self.trace[register][step]
     }
 
     fn read_row_into(&self, step: usize, target: &mut [B]) {
@@ -346,18 +358,6 @@ impl<B: StarkField> Trace for TraceTable<B> {
 
     fn into_columns(self) -> Vec<Vec<B>> {
         self.trace
-    }
-
-    fn width(&self) -> usize {
-        self.trace.len()
-    }
-
-    fn length(&self) -> usize {
-        self.trace[0].len()
-    }
-
-    fn get(&self, register: usize, step: usize) -> B {
-        self.trace[register][step]
     }
 }
 

--- a/verifier/src/channel.rs
+++ b/verifier/src/channel.rs
@@ -52,7 +52,7 @@ where
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Creates and returns a new verifier channel initialized from the specified `proof`.
-    pub fn new<A: Air<BaseElement = B>>(air: &A, proof: StarkProof) -> Result<Self, VerifierError> {
+    pub fn new<A: Air<BaseField = B>>(air: &A, proof: StarkProof) -> Result<Self, VerifierError> {
         // make AIR and proof base fields are the same
         if B::get_modulus_le_bytes() != proof.context.field_modulus_bytes() {
             return Err(VerifierError::InconsistentBaseField);

--- a/verifier/src/composer.rs
+++ b/verifier/src/composer.rs
@@ -10,15 +10,15 @@ use utils::collections::Vec;
 // DEEP COMPOSER
 // ================================================================================================
 
-pub struct DeepComposer<A: Air, E: FieldElement + From<A::BaseElement>> {
+pub struct DeepComposer<A: Air, E: FieldElement + From<A::BaseField>> {
     field_extension: FieldExtension,
     cc: DeepCompositionCoefficients<E>,
-    x_coordinates: Vec<A::BaseElement>,
+    x_coordinates: Vec<A::BaseField>,
     z: E,
     next_z: E,
 }
 
-impl<A: Air, E: FieldElement + From<A::BaseElement>> DeepComposer<A, E> {
+impl<A: Air, E: FieldElement + From<A::BaseField>> DeepComposer<A, E> {
     /// Creates a new composer for computing DEEP composition polynomial values.
     pub fn new(
         air: &A,
@@ -29,7 +29,7 @@ impl<A: Air, E: FieldElement + From<A::BaseElement>> DeepComposer<A, E> {
         // compute LDE domain coordinates for all query positions
         let g_lde = air.lde_domain_generator();
         let domain_offset = air.domain_offset();
-        let x_coordinates: Vec<A::BaseElement> = query_positions
+        let x_coordinates: Vec<A::BaseField> = query_positions
             .iter()
             .map(|&p| g_lde.exp((p as u64).into()) * domain_offset)
             .collect();
@@ -62,7 +62,7 @@ impl<A: Air, E: FieldElement + From<A::BaseElement>> DeepComposer<A, E> {
     /// this function via the `ood_frame` parameter.
     pub fn compose_registers(
         &self,
-        queried_trace_states: Vec<Vec<A::BaseElement>>,
+        queried_trace_states: Vec<Vec<A::BaseField>>,
         ood_frame: EvaluationFrame<E>,
     ) -> Vec<E> {
         let trace_at_z1 = ood_frame.current();

--- a/verifier/src/evaluator.rs
+++ b/verifier/src/evaluator.rs
@@ -11,7 +11,7 @@ use utils::collections::Vec;
 // ================================================================================================
 
 /// Evaluates constraints for the specified evaluation frame.
-pub fn evaluate_constraints<A: Air, E: FieldElement<BaseField = A::BaseElement>>(
+pub fn evaluate_constraints<A: Air, E: FieldElement<BaseField = A::BaseField>>(
     air: &A,
     coefficients: ConstraintCompositionCoefficients<E>,
     ood_frame: &EvaluationFrame<E>,

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -103,60 +103,60 @@ pub fn verify<AIR: Air>(
             HashFunction::Blake3_256 => {
                 let public_coin = RandomCoin::new(&public_coin_seed);
                 let channel = VerifierChannel::new(&air, proof)?;
-                perform_verification::<AIR, AIR::BaseElement, Blake3_256<AIR::BaseElement>>(air, channel, public_coin)
+                perform_verification::<AIR, AIR::BaseField, Blake3_256<AIR::BaseField>>(air, channel, public_coin)
             }
             HashFunction::Blake3_192 => {
                 let public_coin = RandomCoin::new(&public_coin_seed);
                 let channel = VerifierChannel::new(&air, proof)?;
-                perform_verification::<AIR, AIR::BaseElement, Blake3_192<AIR::BaseElement>>(air, channel, public_coin)
+                perform_verification::<AIR, AIR::BaseField, Blake3_192<AIR::BaseField>>(air, channel, public_coin)
             }
             HashFunction::Sha3_256 => {
                 let public_coin = RandomCoin::new(&public_coin_seed);
                 let channel = VerifierChannel::new(&air, proof)?;
-                perform_verification::<AIR, AIR::BaseElement, Sha3_256<AIR::BaseElement>>(air, channel, public_coin)
+                perform_verification::<AIR, AIR::BaseField, Sha3_256<AIR::BaseField>>(air, channel, public_coin)
             }
         },
         FieldExtension::Quadratic => {
-            if !<QuadExtension<AIR::BaseElement>>::is_supported() {
+            if !<QuadExtension<AIR::BaseField>>::is_supported() {
                 return Err(VerifierError::UnsupportedFieldExtension(2));
             }
             match air.options().hash_fn() {
                 HashFunction::Blake3_256 => {
                     let public_coin = RandomCoin::new(&public_coin_seed);
                     let channel = VerifierChannel::new(&air, proof)?;
-                    perform_verification::<AIR, QuadExtension<AIR::BaseElement>, Blake3_256<AIR::BaseElement>>(air, channel, public_coin)
+                    perform_verification::<AIR, QuadExtension<AIR::BaseField>, Blake3_256<AIR::BaseField>>(air, channel, public_coin)
                 }
                 HashFunction::Blake3_192 => {
                     let public_coin = RandomCoin::new(&public_coin_seed);
                     let channel = VerifierChannel::new(&air, proof)?;
-                    perform_verification::<AIR, QuadExtension<AIR::BaseElement>, Blake3_192<AIR::BaseElement>>(air, channel, public_coin)
+                    perform_verification::<AIR, QuadExtension<AIR::BaseField>, Blake3_192<AIR::BaseField>>(air, channel, public_coin)
                 }
                 HashFunction::Sha3_256 => {
                     let public_coin = RandomCoin::new(&public_coin_seed);
                     let channel = VerifierChannel::new(&air, proof)?;
-                    perform_verification::<AIR, QuadExtension<AIR::BaseElement>, Sha3_256<AIR::BaseElement>>(air, channel, public_coin)
+                    perform_verification::<AIR, QuadExtension<AIR::BaseField>, Sha3_256<AIR::BaseField>>(air, channel, public_coin)
                 }
             }
         },
         FieldExtension::Cubic => {
-            if !<CubeExtension<AIR::BaseElement>>::is_supported() {
+            if !<CubeExtension<AIR::BaseField>>::is_supported() {
                 return Err(VerifierError::UnsupportedFieldExtension(3));
             }
             match air.options().hash_fn() {
                 HashFunction::Blake3_256 => {
                     let public_coin = RandomCoin::new(&public_coin_seed);
                     let channel = VerifierChannel::new(&air, proof)?;
-                    perform_verification::<AIR, CubeExtension<AIR::BaseElement>, Blake3_256<AIR::BaseElement>>(air, channel, public_coin)
+                    perform_verification::<AIR, CubeExtension<AIR::BaseField>, Blake3_256<AIR::BaseField>>(air, channel, public_coin)
                 }
                 HashFunction::Blake3_192 => {
                     let public_coin = RandomCoin::new(&public_coin_seed);
                     let channel = VerifierChannel::new(&air, proof)?;
-                    perform_verification::<AIR, CubeExtension<AIR::BaseElement>, Blake3_192<AIR::BaseElement>>(air, channel, public_coin)
+                    perform_verification::<AIR, CubeExtension<AIR::BaseField>, Blake3_192<AIR::BaseField>>(air, channel, public_coin)
                 }
                 HashFunction::Sha3_256 => {
                     let public_coin = RandomCoin::new(&public_coin_seed);
                     let channel = VerifierChannel::new(&air, proof)?;
-                    perform_verification::<AIR, CubeExtension<AIR::BaseElement>, Sha3_256<AIR::BaseElement>>(air, channel, public_coin)
+                    perform_verification::<AIR, CubeExtension<AIR::BaseField>, Sha3_256<AIR::BaseField>>(air, channel, public_coin)
                 }
             }
         },
@@ -169,13 +169,13 @@ pub fn verify<AIR: Air>(
 /// attests to a correct execution of the computation specified by the provided `air`.
 fn perform_verification<A, E, H>(
     air: A,
-    mut channel: VerifierChannel<A::BaseElement, E, H>,
-    mut public_coin: RandomCoin<A::BaseElement, H>,
+    mut channel: VerifierChannel<A::BaseField, E, H>,
+    mut public_coin: RandomCoin<A::BaseField, H>,
 ) -> Result<(), VerifierError>
 where
     A: Air,
-    E: FieldElement<BaseField = A::BaseElement>,
-    H: ElementHasher<BaseField = A::BaseElement>,
+    E: FieldElement<BaseField = A::BaseField>,
+    H: ElementHasher<BaseField = A::BaseField>,
 {
     // 1 ----- trace commitment -------------------------------------------------------------------
     // read the commitment to evaluations of the trace polynomials over the LDE domain sent by the

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! 1. Define an *algebraic intermediate representation* (AIR) for your computation. This can
 //!    be done by implementing [Air] trait.
-//! 2. Execute your computation and record its execution trace in [ExecutionTrace] struct.
+//! 2. Execute your computation and record its execution trace in [TraceTable] struct.
 //! 3. Execute [prove()] function and supply the AIR of your computation together with its
 //!    execution trace as input parameters. The function will produce a instance of [StarkProof]
 //!    as an output.
@@ -96,21 +96,21 @@
 //! | ...       |
 //! | 1,048,575 | 247770943907079986105389697876176586605 |
 //!
-//! To record the trace, we'll use the [ExecutionTrace] struct. The function below, is just a
+//! To record the trace, we'll use the [TraceTable] struct. The function below, is just a
 //! modified version of the `do_work()` function which records every intermediate state of the
-//! computation in the [ExecutionTrace] struct:
+//! computation in the [TraceTable] struct:
 //!
 //! ```no_run
 //! use winterfell::{
 //!     math::{fields::f128::BaseElement, FieldElement},
-//!     ExecutionTrace,
+//!     TraceTable,
 //! };
 //!
-//! pub fn build_do_work_trace(start: BaseElement, n: usize) -> ExecutionTrace<BaseElement> {
+//! pub fn build_do_work_trace(start: BaseElement, n: usize) -> TraceTable<BaseElement> {
 //!     // Instantiate the trace with a given width and length; this will allocate all
 //!     // required memory for the trace
 //!     let trace_width = 1;
-//!     let mut trace = ExecutionTrace::new(trace_width, n);
+//!     let mut trace = TraceTable::new(trace_width, n);
 //!
 //!     // Fill the trace with data; the first closure initializes the first state of the
 //!     // computation; the second closure computes the next state of the computation based
@@ -253,13 +253,13 @@
 //! # use winterfell::{
 //! #    math::{fields::f128::BaseElement, FieldElement},
 //! #    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable,
-//! #    TraceInfo, TransitionConstraintDegree, ExecutionTrace, FieldExtension,
+//! #    TraceInfo, TransitionConstraintDegree, TraceTable, FieldExtension,
 //! #    HashFunction, Prover, ProofOptions, StarkProof, Trace,
 //! # };
 //! #
-//! # pub fn build_do_work_trace(start: BaseElement, n: usize) -> ExecutionTrace<BaseElement> {
+//! # pub fn build_do_work_trace(start: BaseElement, n: usize) -> TraceTable<BaseElement> {
 //! #     let trace_width = 1;
-//! #     let mut trace = ExecutionTrace::new(trace_width, n);
+//! #     let mut trace = TraceTable::new(trace_width, n);
 //! #     trace.fill(
 //! #         |state| {
 //! #             state[0] = start;
@@ -361,7 +361,7 @@
 //! impl Prover for WorkProver {
 //!     type BaseField = BaseElement;
 //!     type Air = WorkAir;
-//!     type Trace = ExecutionTrace<Self::BaseField>;
+//!     type Trace = TraceTable<Self::BaseField>;
 //!
 //!     fn options(&self) -> &ProofOptions {
 //!         &self.options
@@ -408,8 +408,8 @@ pub use prover::{
     crypto, iterators, math, Air, AirContext, Assertion, BoundaryConstraint,
     BoundaryConstraintGroup, ByteReader, ByteWriter, ConstraintCompositionCoefficients,
     ConstraintDivisor, DeepCompositionCoefficients, Deserializable, DeserializationError,
-    EvaluationFrame, ExecutionTrace, ExecutionTraceFragment, FieldExtension, HashFunction,
-    ProofOptions, Prover, ProverError, Serializable, StarkProof, Trace, TraceInfo,
-    TransitionConstraintDegree, TransitionConstraintGroup,
+    EvaluationFrame, FieldExtension, HashFunction, ProofOptions, Prover, ProverError, Serializable,
+    StarkProof, Trace, TraceInfo, TraceTable, TraceTableFragment, TransitionConstraintDegree,
+    TransitionConstraintGroup,
 };
 pub use verifier::{verify, VerifierError};

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -360,7 +360,8 @@
 //!
 //! impl Prover for WorkProver {
 //!     type BaseField = BaseElement;
-//!     type AIR = WorkAir;
+//!     type Air = WorkAir;
+//!     type Trace = ExecutionTrace<Self::BaseField>;
 //!
 //!     fn options(&self) -> &ProofOptions {
 //!         &self.options
@@ -408,7 +409,7 @@ pub use prover::{
     BoundaryConstraintGroup, ByteReader, ByteWriter, ConstraintCompositionCoefficients,
     ConstraintDivisor, DeepCompositionCoefficients, Deserializable, DeserializationError,
     EvaluationFrame, ExecutionTrace, ExecutionTraceFragment, FieldExtension, HashFunction,
-    ProofOptions, Prover, ProverError, Serializable, StarkProof, TraceInfo,
+    ProofOptions, Prover, ProverError, Serializable, StarkProof, Trace, TraceInfo,
     TransitionConstraintDegree, TransitionConstraintGroup,
 };
 pub use verifier::{verify, VerifierError};

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -254,7 +254,7 @@
 //! #    math::{fields::f128::BaseElement, FieldElement},
 //! #    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable,
 //! #    TraceInfo, TransitionConstraintDegree, ExecutionTrace, FieldExtension,
-//! #    HashFunction, Prover, ProofOptions, StarkProof,
+//! #    HashFunction, Prover, ProofOptions, StarkProof, Trace,
 //! # };
 //! #
 //! # pub fn build_do_work_trace(start: BaseElement, n: usize) -> ExecutionTrace<BaseElement> {

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -177,7 +177,7 @@
 //! impl Air for WorkAir {
 //!     // First, we'll specify which finite field to use for our computation, and also how
 //!     // the public inputs must look like.
-//!     type BaseElement = BaseElement;
+//!     type BaseField = BaseElement;
 //!     type PublicInputs = PublicInputs;
 //!
 //!     // Here, we'll construct a new instance of our computation which is defined by 3
@@ -206,7 +206,7 @@
 //!     // be valid, if for all valid state transitions, transition constraints evaluate to all
 //!     // zeros, and for any invalid transition, at least one constraint evaluates to a non-zero
 //!     // value. The `frame` parameter will contain current and next states of the computation.
-//!     fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+//!     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
 //!         &self,
 //!         frame: &EvaluationFrame<E>,
 //!         _periodic_values: &[E],
@@ -224,7 +224,7 @@
 //!     // Here, we'll define a set of assertions about the execution trace which must be
 //!     // satisfied for the computation to be valid. Essentially, this ties computation's
 //!     // execution trace to the public inputs.
-//!     fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+//!     fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
 //!         // for our computation to be valid, value in column 0 at step 0 must be equal to the
 //!         // starting value, and at the last step it must be equal to the result.
 //!         let last_step = self.trace_length() - 1;
@@ -236,7 +236,7 @@
 //!
 //!     // This is just boilerplate which is used by the Winterfell prover/verifier to retrieve
 //!     // the context of the computation.
-//!     fn context(&self) -> &AirContext<Self::BaseElement> {
+//!     fn context(&self) -> &AirContext<Self::BaseField> {
 //!         &self.context
 //!     }
 //! }
@@ -291,7 +291,7 @@
 //! # }
 //! #
 //! # impl Air for WorkAir {
-//! #     type BaseElement = BaseElement;
+//! #     type BaseField = BaseElement;
 //! #     type PublicInputs = PublicInputs;
 //! #
 //! #     fn new(trace_info: TraceInfo, pub_inputs: PublicInputs, options: ProofOptions) -> Self {
@@ -304,7 +304,7 @@
 //! #         }
 //! #     }
 //! #
-//! #     fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+//! #     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
 //! #         &self,
 //! #         frame: &EvaluationFrame<E>,
 //! #         _periodic_values: &[E],
@@ -315,7 +315,7 @@
 //! #         result[0] = frame.next()[0] - next_state;
 //! #     }
 //! #
-//! #     fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+//! #     fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
 //! #         let last_step = self.trace_length() - 1;
 //! #         vec![
 //! #             Assertion::single(0, 0, self.start),
@@ -323,7 +323,7 @@
 //! #         ]
 //! #     }
 //! #
-//! #     fn context(&self) -> &AirContext<Self::BaseElement> {
+//! #     fn context(&self) -> &AirContext<Self::BaseField> {
 //! #         &self.context
 //! #     }
 //! # }

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -253,8 +253,8 @@
 //! # use winterfell::{
 //! #    math::{fields::f128::BaseElement, FieldElement},
 //! #    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable,
-//! #    TraceInfo, TransitionConstraintDegree,
-//! #    ExecutionTrace, FieldExtension, HashFunction, ProofOptions, StarkProof,
+//! #    TraceInfo, TransitionConstraintDegree, ExecutionTrace, FieldExtension,
+//! #    HashFunction, Prover, ProofOptions, StarkProof,
 //! # };
 //! #
 //! # pub fn build_do_work_trace(start: BaseElement, n: usize) -> ExecutionTrace<BaseElement> {
@@ -348,9 +348,29 @@
 //!     128, // FRI max remainder length
 //! );
 //!
+//! struct WorkProver {
+//!     options: ProofOptions
+//! }
+//!
+//! impl WorkProver {
+//!     pub fn new(options: ProofOptions) -> Self {
+//!         Self { options }
+//!     }
+//! }
+//!
+//! impl Prover for WorkProver {
+//!     type BaseField = BaseElement;
+//!     type AIR = WorkAir;
+//!
+//!     fn options(&self) -> &ProofOptions {
+//!         &self.options
+//!     }
+//! }
+//!
 //! // Generate the proof.
 //! let pub_inputs = PublicInputs { start, result };
-//! let proof = winterfell::prove::<WorkAir>(trace, pub_inputs, options).unwrap();
+//! let prover = WorkProver::new(options);
+//! let proof = prover.prove(trace, pub_inputs).unwrap();
 //!
 //! // Verify the proof. The number of steps and options are encoded in the proof itself,
 //! // so we don't need to pass them explicitly to the verifier.
@@ -384,11 +404,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use prover::{
-    crypto, iterators, math, prove, Air, AirContext, Assertion, BoundaryConstraint,
+    crypto, iterators, math, Air, AirContext, Assertion, BoundaryConstraint,
     BoundaryConstraintGroup, ByteReader, ByteWriter, ConstraintCompositionCoefficients,
     ConstraintDivisor, DeepCompositionCoefficients, Deserializable, DeserializationError,
     EvaluationFrame, ExecutionTrace, ExecutionTraceFragment, FieldExtension, HashFunction,
-    ProofOptions, ProverError, Serializable, StarkProof, TraceInfo, TransitionConstraintDegree,
-    TransitionConstraintGroup,
+    ProofOptions, Prover, ProverError, Serializable, StarkProof, TraceInfo,
+    TransitionConstraintDegree, TransitionConstraintGroup,
 };
 pub use verifier::{verify, VerifierError};

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -363,15 +363,22 @@
 //!     type Air = WorkAir;
 //!     type Trace = TraceTable<Self::BaseField>;
 //!
+//!     fn get_pub_inputs(&self, trace: &Self::Trace) -> PublicInputs {
+//!         let last_step = trace.length() - 1;
+//!         PublicInputs {
+//!             start: trace.get(0, 0),
+//!             result: trace.get(0, last_step),
+//!         }
+//!     }
+//!
 //!     fn options(&self) -> &ProofOptions {
 //!         &self.options
 //!     }
 //! }
 //!
 //! // Generate the proof.
-//! let pub_inputs = PublicInputs { start, result };
 //! let prover = WorkProver::new(options);
-//! let proof = prover.prove(trace, pub_inputs).unwrap();
+//! let proof = prover.prove(trace).unwrap();
 //!
 //! // Verify the proof. The number of steps and options are encoded in the proof itself,
 //! // so we don't need to pass them explicitly to the verifier.


### PR DESCRIPTION
This PR supersedes #58. Moving trace building into the prover seems like too big of a change and may sacrifice flexibility. Instead, this PR takes the following approach:

We introduce a `Prover` trait instead of a single `prover::prove()` function. We also split `ExecutionTrace` struct into two parts:
1. `Trace` trait, which is required for the prover to work.
2. `TraceTable` struct, which implements `Trace` trait can be used to build trace tables which should suffice for most use cases.

The idea of the above is that users of the library can provide different implementations of `Trace` trait which may better work for their use cases, and in case a generic trace table works, they can use `TraceTable` struct.

In the context of RAPs, we can update either `Prover` or `Trace` traits to expose methods needed for construction of auxiliary columns. Which one is more appropriate, can be decided later on.

Tasks for this PR:

- [x]  Implement `Prover` trait
- [x] Split `ExecutionTrace` struct into `Trace` trait and `TraceTable` struct.
- [x] Expose public input getter  in the `Prover` trait.
- [x] Update examples
- [x] Update documentation