### PR TITLE
Rp64_256 improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1 (TBD) - crypto
+* Implemented digest to array conversion for Rp64_256 digest.
+* Exposed some internal functions of Rp64_256 publicly.
+
 ## 0.3.0 (2022-01-04)
 * Added `f64` field.
 * Added support for cubic field extensions.

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-crypto"
-version = "0.3.0"
+version = "0.3.1"
 description = "Cryptographic library for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-crypto/0.3.0"
+documentation = "https://docs.rs/winter-crypto/0.3.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "merkle-tree", "hash"]
 edition = "2021"

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -36,6 +36,7 @@ One of the core operations performed during STARK proof generation is constructi
 
 | CPU                         | BLAKE3_256 | SHA3_256 | RP64_256 | RP62_248 |
 | --------------------------- | :--------: | :------: | :------: | :------: |
+| Apple M1 Pro                | 76 ns      | 227 ns   | 8.6 us   | 7.1 us   |
 | AMD Ryzen 9 5950X @ 3.4 GHz | 62 ns      | 310 ns   | 8.7 us   | 6.9 us   |
 | Core i9-9980KH @ 2.4 GHz    | 66 ns      | 400 ns   | -        | 6.6 us   |
 | Core i5-7300U @ 2.6 GHz     | 81 ns      | 540 ns   | -        | 9.5 us   |

--- a/crypto/src/hash/rescue/rp64_256/digest.rs
+++ b/crypto/src/hash/rescue/rp64_256/digest.rs
@@ -67,6 +67,18 @@ impl Deserializable for ElementDigest {
     }
 }
 
+impl From<[BaseElement; DIGEST_SIZE]> for ElementDigest {
+    fn from(value: [BaseElement; DIGEST_SIZE]) -> Self {
+        Self(value)
+    }
+}
+
+impl From<ElementDigest> for [BaseElement; DIGEST_SIZE] {
+    fn from(value: ElementDigest) -> Self {
+        value.0
+    }
+}
+
 // TESTS
 // ================================================================================================
 

--- a/crypto/src/hash/rescue/rp64_256/tests.rs
+++ b/crypto/src/hash/rescue/rp64_256/tests.rs
@@ -26,7 +26,7 @@ fn test_sbox() {
     expected.iter_mut().for_each(|v| *v = v.exp(ALPHA));
 
     let mut actual = state;
-    super::apply_sbox(&mut actual);
+    Rp64_256::apply_sbox(&mut actual);
 
     assert_eq!(expected, actual);
 }
@@ -39,7 +39,7 @@ fn test_inv_sbox() {
     expected.iter_mut().for_each(|v| *v = v.exp(INV_ALPHA));
 
     let mut actual = state;
-    super::apply_inv_sbox(&mut actual);
+    Rp64_256::apply_inv_sbox(&mut actual);
 
     assert_eq!(expected, actual);
 }
@@ -61,7 +61,7 @@ fn apply_permutation() {
         BaseElement::new(11),
     ];
 
-    super::apply_permutation(&mut state);
+    Rp64_256::apply_permutation(&mut state);
 
     // expected values are obtained by executing sage reference implementation code
     let expected = vec![


### PR DESCRIPTION
This PR makes a few minor updates to Rp64_256 hash function implementation:

* Implemented digest to array conversion for Rp64_256 digest.
* Makes `apply_permutation()` and `apply_round()` functions public. 