### PR TITLE
ExtensionOf trait

### DIFF
--- a/math/benches/fft.rs
+++ b/math/benches/fft.rs
@@ -8,7 +8,7 @@ use rand_utils::rand_vector;
 use std::time::Duration;
 use winter_math::{
     fft,
-    fields::{f128, f62, f64, QuadExtension},
+    fields::{f128, f62, f64, CubeExtension, QuadExtension},
     FieldElement, StarkField,
 };
 
@@ -108,6 +108,8 @@ fn bench_fft(c: &mut Criterion) {
     fft_evaluate_poly::<f62::BaseElement, QuadExtension<f62::BaseElement>>(c, "f62_quad");
     fft_evaluate_poly::<f64::BaseElement, QuadExtension<f64::BaseElement>>(c, "f64_quad");
     fft_evaluate_poly::<f128::BaseElement, QuadExtension<f128::BaseElement>>(c, "f128_quad");
+
+    fft_evaluate_poly::<f64::BaseElement, CubeExtension<f64::BaseElement>>(c, "f64_cube");
 
     fft_interpolate_poly::<f62::BaseElement, f62::BaseElement>(c, "f62");
     fft_interpolate_poly::<f64::BaseElement, f64::BaseElement>(c, "f64");

--- a/math/src/fft/serial.rs
+++ b/math/src/fft/serial.rs
@@ -186,7 +186,7 @@ where
     let i = offset;
     let j = offset + stride;
     let temp = values[i];
-    values[j] *= E::from(twiddle);
+    values[j] = values[j].mul_base(twiddle);
     values[i] = temp + values[j];
     values[j] = temp - values[j];
 }

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{ExtensibleField, FieldElement};
+use super::{ExtensibleField, ExtensionOf, FieldElement};
 use core::{
     convert::TryFrom,
     fmt,
@@ -134,6 +134,14 @@ impl<B: ExtensibleField<3>> FieldElement for CubeExtension<B> {
         let ptr = elements.as_ptr();
         let len = elements.len() * 3;
         unsafe { slice::from_raw_parts(ptr as *const Self::BaseField, len) }
+    }
+}
+
+impl<B: ExtensibleField<3>> ExtensionOf<B> for CubeExtension<B> {
+    #[inline(always)]
+    fn mul_base(self, other: B) -> Self {
+        let result = <B as ExtensibleField<3>>::mul_base([self.0, self.1, self.2], other);
+        Self(result[0], result[1], result[2])
     }
 }
 

--- a/math/src/field/extensions/mod.rs
+++ b/math/src/field/extensions/mod.rs
@@ -9,4 +9,4 @@ pub use quadratic::QuadExtension;
 mod cubic;
 pub use cubic::CubeExtension;
 
-use super::{ExtensibleField, FieldElement};
+use super::{ExtensibleField, ExtensionOf, FieldElement};

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{ExtensibleField, FieldElement};
+use super::{ExtensibleField, ExtensionOf, FieldElement};
 use core::{
     convert::TryFrom,
     fmt,
@@ -126,6 +126,14 @@ impl<B: ExtensibleField<2>> FieldElement for QuadExtension<B> {
         let ptr = elements.as_ptr();
         let len = elements.len() * 2;
         unsafe { slice::from_raw_parts(ptr as *const Self::BaseField, len) }
+    }
+}
+
+impl<B: ExtensibleField<2>> ExtensionOf<B> for QuadExtension<B> {
+    #[inline(always)]
+    fn mul_base(self, other: B) -> Self {
+        let result = <B as ExtensibleField<2>>::mul_base([self.0, self.1], other);
+        Self(result[0], result[1])
     }
 }
 

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -10,10 +10,7 @@
 //! significant thought given to performance, and the implementations of most operations are
 //! sub-optimal as well.
 
-use super::{
-    traits::{FieldElement, StarkField},
-    ExtensibleField,
-};
+use super::{ExtensibleField, ExtensionOf, FieldElement, StarkField};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{Debug, Display, Formatter},
@@ -161,6 +158,14 @@ impl StarkField for BaseElement {
     }
 }
 
+/// A base [StarkField] field is always an extension of itself.
+impl ExtensionOf<BaseElement> for BaseElement {
+    #[inline(always)]
+    fn mul_base(self, other: BaseElement) -> Self {
+        self * other
+    }
+}
+
 impl Randomizable for BaseElement {
     const VALUE_SIZE: usize = Self::ELEMENT_BYTES;
 
@@ -256,6 +261,11 @@ impl ExtensibleField<2> for BaseElement {
     }
 
     #[inline(always)]
+    fn mul_base(a: [Self; 2], b: Self) -> [Self; 2] {
+        [a[0] * b, a[1] * b]
+    }
+
+    #[inline(always)]
     fn frobenius(x: [Self; 2]) -> [Self; 2] {
         [x[0] + x[1], Self::ZERO - x[1]]
     }
@@ -268,6 +278,11 @@ impl ExtensibleField<2> for BaseElement {
 /// sufficient security level.
 impl ExtensibleField<3> for BaseElement {
     fn mul(_a: [Self; 3], _b: [Self; 3]) -> [Self; 3] {
+        unimplemented!()
+    }
+
+    #[inline(always)]
+    fn mul_base(_a: [Self; 3], _b: Self) -> [Self; 3] {
         unimplemented!()
     }
 

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -10,7 +10,7 @@
 //! significant thought given to performance, and the implementations of most operations are
 //! sub-optimal as well.
 
-use super::{ExtensibleField, ExtensionOf, FieldElement, StarkField};
+use super::{ExtensibleField, FieldElement, StarkField};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{Debug, Display, Formatter},
@@ -155,14 +155,6 @@ impl StarkField for BaseElement {
     #[inline]
     fn as_int(&self) -> Self::PositiveInteger {
         self.0
-    }
-}
-
-/// A base [StarkField] field is always an extension of itself.
-impl ExtensionOf<BaseElement> for BaseElement {
-    #[inline(always)]
-    fn mul_base(self, other: BaseElement) -> Self {
-        self * other
     }
 }
 

--- a/math/src/field/f128/tests.rs
+++ b/math/src/field/f128/tests.rs
@@ -4,10 +4,10 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{
-    AsBytes, BaseElement, ByteReader, Deserializable, DeserializationError, ExtensionOf,
-    FieldElement, StarkField, M,
+    AsBytes, BaseElement, ByteReader, Deserializable, DeserializationError, FieldElement,
+    StarkField, M,
 };
-use crate::field::QuadExtension;
+use crate::field::{ExtensionOf, QuadExtension};
 use core::convert::TryFrom;
 use num_bigint::BigUint;
 use rand_utils::{rand_value, rand_vector};

--- a/math/src/field/f128/tests.rs
+++ b/math/src/field/f128/tests.rs
@@ -4,9 +4,10 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{
-    AsBytes, BaseElement, ByteReader, Deserializable, DeserializationError, FieldElement,
-    StarkField, M,
+    AsBytes, BaseElement, ByteReader, Deserializable, DeserializationError, ExtensionOf,
+    FieldElement, StarkField, M,
 };
+use crate::field::QuadExtension;
 use core::convert::TryFrom;
 use num_bigint::BigUint;
 use rand_utils::{rand_value, rand_vector};
@@ -143,6 +144,19 @@ fn get_root_of_unity() {
 fn test_g_is_2_exp_40_root() {
     let g = BaseElement::TWO_ADIC_ROOT_OF_UNITY;
     assert_eq!(g.exp(1u128 << 40), BaseElement::ONE);
+}
+
+// FIELD EXTENSIONS
+// ================================================================================================
+
+#[test]
+fn quad_mul_base() {
+    let a = <QuadExtension<BaseElement>>::new(rand_value(), rand_value());
+    let b0 = rand_value();
+    let b = <QuadExtension<BaseElement>>::new(b0, BaseElement::ZERO);
+
+    let expected = a * b;
+    assert_eq!(expected, a.mul_base(b0));
 }
 
 // SERIALIZATION / DESERIALIZATION

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -9,7 +9,7 @@
 //! fast modular arithmetic including branchless multiplication and addition. Base elements are
 //! stored in the Montgomery form using `u64` as the backing type.
 
-use super::{ExtensibleField, ExtensionOf, FieldElement, StarkField};
+use super::{ExtensibleField, FieldElement, StarkField};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{Debug, Display, Formatter},
@@ -185,13 +185,6 @@ impl StarkField for BaseElement {
         let result = mul(self.0, 1);
         // since the result of multiplication can be in [0, 2M), we need to normalize it
         normalize(result)
-    }
-}
-
-impl ExtensionOf<BaseElement> for BaseElement {
-    #[inline(always)]
-    fn mul_base(self, other: BaseElement) -> Self {
-        self * other
     }
 }
 

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -9,10 +9,7 @@
 //! fast modular arithmetic including branchless multiplication and addition. Base elements are
 //! stored in the Montgomery form using `u64` as the backing type.
 
-use super::{
-    traits::{FieldElement, StarkField},
-    ExtensibleField,
-};
+use super::{ExtensibleField, ExtensionOf, FieldElement, StarkField};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{Debug, Display, Formatter},
@@ -191,6 +188,13 @@ impl StarkField for BaseElement {
     }
 }
 
+impl ExtensionOf<BaseElement> for BaseElement {
+    #[inline(always)]
+    fn mul_base(self, other: BaseElement) -> Self {
+        self * other
+    }
+}
+
 impl Randomizable for BaseElement {
     const VALUE_SIZE: usize = Self::ELEMENT_BYTES;
 
@@ -300,6 +304,11 @@ impl ExtensibleField<2> for BaseElement {
     }
 
     #[inline(always)]
+    fn mul_base(a: [Self; 2], b: Self) -> [Self; 2] {
+        [a[0] * b, a[1] * b]
+    }
+
+    #[inline(always)]
     fn frobenius(x: [Self; 2]) -> [Self; 2] {
         [x[0] + x[1], -x[1]]
     }
@@ -337,6 +346,11 @@ impl ExtensibleField<3> for BaseElement {
             a0b1_a1b0_minus_2a1b2_minus_2a2b1_minus_2a2b2,
             a0b2_a1b1_a2b0_minus_2a2b2,
         ]
+    }
+
+    #[inline(always)]
+    fn mul_base(a: [Self; 3], b: Self) -> [Self; 3] {
+        [a[0] * b, a[1] * b, a[2] * b]
     }
 
     #[inline(always)]

--- a/math/src/field/f62/tests.rs
+++ b/math/src/field/f62/tests.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{AsBytes, BaseElement, DeserializationError, FieldElement, Serializable, StarkField};
-use crate::field::{CubeExtension, QuadExtension};
+use crate::field::{CubeExtension, ExtensionOf, QuadExtension};
 use core::convert::TryFrom;
 use num_bigint::BigUint;
 use proptest::prelude::*;
@@ -119,8 +119,22 @@ fn equals() {
     assert_ne!(a.as_bytes(), b.as_bytes());
 }
 
+// QUADRATIC EXTENSION
+// ------------------------------------------------------------------------------------------------
+
+#[test]
+fn quad_mul_base() {
+    let a = <QuadExtension<BaseElement>>::new(rand_value(), rand_value());
+    let b0 = rand_value();
+    let b = <QuadExtension<BaseElement>>::new(b0, BaseElement::ZERO);
+
+    let expected = a * b;
+    assert_eq!(expected, a.mul_base(b0));
+}
+
 // CUBIC EXTENSION
 // ------------------------------------------------------------------------------------------------
+
 #[test]
 fn cube_mul() {
     // identity
@@ -183,6 +197,16 @@ fn cube_mul() {
         BaseElement::new(4611610241754952409),
     );
     assert_eq!(expected, a * b);
+}
+
+#[test]
+fn cube_mul_base() {
+    let a = <CubeExtension<BaseElement>>::new(rand_value(), rand_value(), rand_value());
+    let b0 = rand_value();
+    let b = <CubeExtension<BaseElement>>::new(b0, BaseElement::ZERO, BaseElement::ZERO);
+
+    let expected = a * b;
+    assert_eq!(expected, a.mul_base(b0));
 }
 
 // ROOTS OF UNITY

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -14,10 +14,7 @@
 //!
 //! Internally, the values are stored in the range $[0, 2^{64})$ using `u64` as the backing type.
 
-use super::{
-    traits::{FieldElement, StarkField},
-    ExtensibleField,
-};
+use super::{ExtensibleField, ExtensionOf, FieldElement, StarkField};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{Debug, Display, Formatter},
@@ -218,6 +215,14 @@ impl StarkField for BaseElement {
     }
 }
 
+/// A base [StarkField] field is always an extension of itself.
+impl ExtensionOf<BaseElement> for BaseElement {
+    #[inline(always)]
+    fn mul_base(self, other: BaseElement) -> Self {
+        self * other
+    }
+}
+
 impl Randomizable for BaseElement {
     const VALUE_SIZE: usize = Self::ELEMENT_BYTES;
 
@@ -353,6 +358,13 @@ impl ExtensibleField<2> for BaseElement {
     }
 
     #[inline(always)]
+    fn mul_base(a: [Self; 2], b: Self) -> [Self; 2] {
+        // multiplying an extension field element by a base field element requires just 2
+        // multiplications in the base field.
+        [a[0] * b, a[1] * b]
+    }
+
+    #[inline(always)]
     fn frobenius(x: [Self; 2]) -> [Self; 2] {
         [x[0] + x[1], -x[1]]
     }
@@ -390,6 +402,13 @@ impl ExtensibleField<3> for BaseElement {
             a0b1_a1b0_a1b2_a2b1_a2b2,
             a0b2_a1b1_a2b0_a2b2,
         ]
+    }
+
+    #[inline(always)]
+    fn mul_base(a: [Self; 3], b: Self) -> [Self; 3] {
+        // multiplying an extension field element by a base field element requires just 3
+        // multiplications in the base field.
+        [a[0] * b, a[1] * b, a[2] * b]
     }
 
     #[inline(always)]

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! Internally, the values are stored in the range $[0, 2^{64})$ using `u64` as the backing type.
 
-use super::{ExtensibleField, ExtensionOf, FieldElement, StarkField};
+use super::{ExtensibleField, FieldElement, StarkField};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{Debug, Display, Formatter},
@@ -212,14 +212,6 @@ impl StarkField for BaseElement {
         } else {
             self.0
         }
-    }
-}
-
-/// A base [StarkField] field is always an extension of itself.
-impl ExtensionOf<BaseElement> for BaseElement {
-    #[inline(always)]
-    fn mul_base(self, other: BaseElement) -> Self {
-        self * other
     }
 }
 

--- a/math/src/field/f64/tests.rs
+++ b/math/src/field/f64/tests.rs
@@ -6,7 +6,7 @@
 use super::{
     AsBytes, BaseElement, DeserializationError, FieldElement, Serializable, StarkField, E, M,
 };
-use crate::field::{CubeExtension, QuadExtension};
+use crate::field::{CubeExtension, ExtensionOf, QuadExtension};
 use core::convert::TryFrom;
 use num_bigint::BigUint;
 use proptest::prelude::*;
@@ -272,6 +272,16 @@ fn quad_mul() {
 }
 
 #[test]
+fn quad_mul_base() {
+    let a = <QuadExtension<BaseElement>>::new(rand_value(), rand_value());
+    let b0 = rand_value();
+    let b = <QuadExtension<BaseElement>>::new(b0, BaseElement::ZERO);
+
+    let expected = a * b;
+    assert_eq!(expected, a.mul_base(b0));
+}
+
+#[test]
 fn quad_conjugate() {
     let m = BaseElement::MODULUS;
 
@@ -361,6 +371,16 @@ fn cube_mul() {
         BaseElement::new(21824696736),
     );
     assert_eq!(expected, a * b);
+}
+
+#[test]
+fn cube_mul_base() {
+    let a = <CubeExtension<BaseElement>>::new(rand_value(), rand_value(), rand_value());
+    let b0 = rand_value();
+    let b = <CubeExtension<BaseElement>>::new(b0, BaseElement::ZERO, BaseElement::ZERO);
+
+    let expected = a * b;
+    assert_eq!(expected, a.mul_base(b0));
 }
 
 // RANDOMIZED TESTS

--- a/math/src/field/mod.rs
+++ b/math/src/field/mod.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 mod traits;
-pub use traits::{ExtensibleField, FieldElement, StarkField};
+pub use traits::{ExtensibleField, ExtensionOf, FieldElement, StarkField};
 
 pub mod f128;
 pub mod f62;

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -277,6 +277,14 @@ pub trait ExtensibleField<const N: usize>: StarkField {
 /// - An element in the extension field can be multiplied by a base field element directly. This
 ///   can be used for optimization purposes as such multiplication could be much more efficient
 ///   than multiplication of two extension field elements.
-pub trait ExtensionOf<F: FieldElement>: From<F> {
-    fn mul_base(self, other: F) -> Self;
+pub trait ExtensionOf<E: FieldElement>: From<E> {
+    fn mul_base(self, other: E) -> Self;
+}
+
+/// A field is always an extension of itself.
+impl<E: FieldElement> ExtensionOf<E> for E {
+    #[inline(always)]
+    fn mul_base(self, other: E) -> Self {
+        self * other
+    }
 }

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -46,13 +46,13 @@ pub trait FieldElement:
     + MulAssign<Self>
     + DivAssign<Self>
     + Neg<Output = Self>
-    + From<<Self as FieldElement>::BaseField>
     + From<u128>
     + From<u64>
     + From<u32>
     + From<u16>
     + From<u8>
     + for<'a> TryFrom<&'a [u8]>
+    + ExtensionOf<<Self as FieldElement>::BaseField>
     + AsBytes
     + Randomizable
     + Serializable
@@ -254,6 +254,10 @@ pub trait ExtensibleField<const N: usize>: StarkField {
     /// Returns a product of `a` and `b` in the field defined by this extension.
     fn mul(a: [Self; N], b: [Self; N]) -> [Self; N];
 
+    /// Returns a product of `a` and `b` in the field defined by this extension. `b` represents
+    /// an element in the base field.
+    fn mul_base(a: [Self; N], b: Self) -> [Self; N];
+
     /// Returns Frobenius automorphisms for `x` in the field defined by this extension.
     fn frobenius(x: [Self; N]) -> [Self; N];
 
@@ -261,4 +265,18 @@ pub trait ExtensibleField<const N: usize>: StarkField {
     fn is_supported() -> bool {
         true
     }
+}
+
+// EXTENSION OF
+// ================================================================================================
+
+/// Specifies that a field is an extension of another field.
+///
+/// Currently, this implies the following:
+/// - An element in the base field can be converted into an element in the extension field.
+/// - An element in the extension field can be multiplied by a base field element directly. This
+///   can be used for optimization purposes as such multiplication could be much more efficient
+///   than multiplication of two extension field elements.
+pub trait ExtensionOf<F: FieldElement>: From<F> {
+    fn mul_base(self, other: F) -> Self;
 }

--- a/math/src/lib.rs
+++ b/math/src/lib.rs
@@ -97,7 +97,7 @@ pub mod fft;
 pub mod polynom;
 
 mod field;
-pub use field::{ExtensibleField, FieldElement, StarkField};
+pub use field::{ExtensibleField, ExtensionOf, FieldElement, StarkField};
 pub mod fields {
     //! Finite field implementations.
     //!


### PR DESCRIPTION
This PR implements `ExtensionOf` trait in the `math` crate. This trait provides a way to multiply an extension field element by a base field element directly (without going through conversion from base field to extension field first). The net result of this is that multiplications of base and extension field elements become much faster. Specifically, for FFT-based polynomial evaluation, when polynomial coefficients are in the extension field, we get about 15% speedup vs. the previous implementation.