### PR TITLE
v0.4 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.4.0 (2022-04-29)
+* Added support for Randomized AIR (with example).
+* Added support for custom number of transition constraint exemptions.
+* Enabled transition constraints of degree *n + 1* when blowup factor is *n*.
+* Moved trace and constraint commitment construction into separate functions in the `Prover` trait.
+* Introduced `Matrix` struct in the prover which is used as a backing type for trace and constraint evaluations.
+* Added `ExtensionOf` trait and implemented it for all supported fields.
+* Sped up inversion in `f64` field by using inversion method based on Fermat’s little theorem.
+* Implemented `Randomizable` trait for `u32`, `u16`, and `u8` types.
+* [BREAKING] `AirContext::new()` now requires `num_assertions` parameter.
+* [BREAKING] Various interface changes in the `Air` trait to support multi-segment traces.
+* Increased min version of `rustc` to 1.60.
+
 ## 0.3.2 (2022-01-20) - crypto
 * Implemented into byte conversion for Rp64_256 digest.
 * Moved capacity elements to the front of the state for Rp64_256.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <a href="https://github.com/novifinancial/winterfell/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
 <img src="https://github.com/novifinancial/winterfell/workflows/CI/badge.svg?branch=main">
 <a href="https://deps.rs/repo/github/novifinancial/winterfell"><img src="https://deps.rs/repo/github/novifinancial/winterfell/status.svg"></a>
-<img src="https://img.shields.io/badge/prover-rustc_1.57+-lightgray.svg">
-<img src="https://img.shields.io/badge/verifier-rustc_1.57+-lightgray.svg">
+<img src="https://img.shields.io/badge/prover-rustc_1.60+-lightgray.svg">
+<img src="https://img.shields.io/badge/verifier-rustc_1.60+-lightgray.svg">
 <a href="https://crates.io/crates/winterfell"><img src="https://img.shields.io/crates/v/winterfell"></a>
 
 A STARK prover and verifier for arbitrary computations.

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winter-air"
-version = "0.3.0"
+version = "0.4.0"
 description = "AIR components for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-air/0.3.0"
+documentation = "https://docs.rs/winter-air/0.4.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "arithmetization", "air"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -20,13 +20,13 @@ default = ["std"]
 std = ["crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-crypto = { version = "0.3", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.3", path = "../fri", package = "winter-fri", default-features = false }
-math = { version = "0.3", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.3", path = "../utils/core", package = "winter-utils", default-features = false }
+crypto = { version = "0.4", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.4", path = "../fri", package = "winter-fri", default-features = false }
+math = { version = "0.4", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.4", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
-rand-utils = { version = "0.3", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.4", path = "../utils/rand", package = "winter-rand-utils" }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winter-crypto"
-version = "0.3.2"
+version = "0.4.0"
 description = "Cryptographic library for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-crypto/0.3.1"
+documentation = "https://docs.rs/winter-crypto/0.4.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "merkle-tree", "hash"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -31,11 +31,11 @@ std = ["blake3/std", "math/std", "sha3/std", "utils/std"]
 
 [dependencies]
 blake3 = { version = "1.0", default-features = false }
-math = { version = "0.3", path = "../math", package = "winter-math", default-features = false }
+math = { version = "0.4", path = "../math", package = "winter-math", default-features = false }
 sha3 = { version = "0.10", default-features = false }
-utils = { version = "0.3", path = "../utils/core", package = "winter-utils", default-features = false }
+utils = { version = "0.4", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
 proptest = "1.0"
-rand-utils = { version = "0.3", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.4", path = "../utils/rand", package = "winter-rand-utils" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.3.0"
+version = "0.4.0"
 description = "Examples of using Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
 categories = ["cryptography"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -26,9 +26,9 @@ default = ["std"]
 std = ["hex/std", "winterfell/std", "core-utils/std", "rand-utils"]
 
 [dependencies]
-winterfell = { version="0.3", path = "../winterfell", default-features = false }
-core-utils = { version = "0.3", path = "../utils/core", package = "winter-utils", default-features = false }
-rand-utils = { version = "0.3", path = "../utils/rand", package = "winter-rand-utils", optional = true }
+winterfell = { version="0.4", path = "../winterfell", default-features = false }
+core-utils = { version = "0.4", path = "../utils/core", package = "winter-utils", default-features = false }
+rand-utils = { version = "0.4", path = "../utils/rand", package = "winter-rand-utils", optional = true }
 hex = { version = "0.4", optional = true }
 log = { version = "0.4", default-features = false }
 blake3 = { version = "1.0", default-features = false }

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winter-fri"
-version = "0.3.0"
+version = "0.4.0"
 description = "Implementation of FRI protocol for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-fri/0.3.0"
+documentation = "https://docs.rs/winter-fri/0.4.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "polynomial", "commitments"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -29,10 +29,10 @@ default = ["std"]
 std = ["crypto/std", "math/std", "utils/std"]
 
 [dependencies]
-crypto = { version = "0.3", path = "../crypto", package = "winter-crypto", default-features = false }
-math = { version = "0.3", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.3", path = "../utils/core", package = "winter-utils", default-features = false }
+crypto = { version = "0.4", path = "../crypto", package = "winter-crypto", default-features = false }
+math = { version = "0.4", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.4", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
-rand-utils = { version = "0.3", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.4", path = "../utils/rand", package = "winter-rand-utils" }

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winter-math"
-version = "0.3.0"
+version = "0.4.0"
 description = "Math library for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-math/0.3.0"
+documentation = "https://docs.rs/winter-math/0.4.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "finite-fields", "polynomials", "fft"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -33,13 +33,13 @@ default = ["std"]
 std = ["utils/std"]
 
 [dependencies]
-utils = { version = "0.3", path = "../utils/core", package = "winter-utils", default-features = false }
+utils = { version = "0.4", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
 num-bigint = "0.4"
 proptest = "1.0"
-rand-utils = { version = "0.3", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.4", path = "../utils/rand", package = "winter-rand-utils" }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winter-prover"
-version = "0.3.0"
+version = "0.4.0"
 description = "Winterfell STARK prover"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-prover/0.3.0"
+documentation = "https://docs.rs/winter-prover/0.4.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "prover"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -21,12 +21,12 @@ default = ["std"]
 std = ["air/std", "crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-air = { version = "0.3", path = "../air", package = "winter-air", default-features = false }
-crypto = { version = "0.3", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.3", path = '../fri', package = "winter-fri", default-features = false }
+air = { version = "0.4", path = "../air", package = "winter-air", default-features = false }
+crypto = { version = "0.4", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.4", path = '../fri', package = "winter-fri", default-features = false }
 log = { version = "0.4", default-features = false }
-math = { version = "0.3", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.3", path = "../utils/core", package = "winter-utils", default-features = false }
+math = { version = "0.4", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.4", path = "../utils/core", package = "winter-utils", default-features = false }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/utils/core/Cargo.toml
+++ b/utils/core/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winter-utils"
-version = "0.3.0"
+version = "0.4.0"
 description = "Utilities for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-utils/0.3.0"
+documentation = "https://docs.rs/winter-utils/0.4.0"
 categories = ["cryptography", "no-std"]
 keywords = ["serialization", "transmute"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false

--- a/utils/rand/Cargo.toml
+++ b/utils/rand/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "winter-rand-utils"
-version = "0.3.0"
+version = "0.4.0"
 description = "Random value generation utilities for Winterfell crates"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-rand-utils/0.3.0"
+documentation = "https://docs.rs/winter-rand-utils/0.4.0"
 categories = ["cryptography"]
 keywords = ["rand"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
 
 [dependencies]
-utils = { version = "0.3", path = "../core", package = "winter-utils" }
+utils = { version = "0.4", path = "../core", package = "winter-utils" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rand =  { version = "0.8" }

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winter-verifier"
-version = "0.3.0"
+version = "0.4.0"
 description = "Winterfell STARK verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/winter-verifier/0.3.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "verifier"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -20,11 +20,11 @@ default = ["std"]
 std = ["air/std", "crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-air = { version = "0.3", path = "../air", package = "winter-air", default-features = false }
-crypto = { version = "0.3", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.3", path = "../fri", package = "winter-fri", default-features = false }
-math = { version = "0.3", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.3", path = "../utils/core", package = "winter-utils", default-features = false }
+air = { version = "0.4", path = "../air", package = "winter-air", default-features = false }
+crypto = { version = "0.4", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.4", path = "../fri", package = "winter-fri", default-features = false }
+math = { version = "0.4", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.4", path = "../utils/core", package = "winter-utils", default-features = false }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/winterfell/Cargo.toml
+++ b/winterfell/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winterfell"
-version = "0.3.0"
+version = "0.4.0"
 description = "Winterfell STARK prover and verifier"
 authors = ["winterfell contributors"]
 readme = "../README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winterfell/0.3.0"
+documentation = "https://docs.rs/winterfell/0.4.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "prover", "verifier"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -21,8 +21,8 @@ default = ["std"]
 std = ["prover/std", "verifier/std"]
 
 [dependencies]
-prover = { version = "0.3", path = "../prover", package = "winter-prover", default-features = false }
-verifier = { version = "0.3", path = "../verifier", package = "winter-verifier", default-features = false }
+prover = { version = "0.4", path = "../prover", package = "winter-prover", default-features = false }
+verifier = { version = "0.4", path = "../verifier", package = "winter-verifier", default-features = false }
 
 # Allow math in docs
 [package.metadata.docs.rs]


### PR DESCRIPTION
This PR prepares the library for v0.4 release.

- [x] Bump version to v0.4
- [x] Set minimum Rust version to 1.60
- [x] Update changelog