### PR TITLE
Add check to speed up RP by 50 %

### DIFF
--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -253,7 +253,16 @@ impl Add for BaseElement {
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, rhs: Self) -> Self {
         let (result, over) = self.0.overflowing_add(rhs.as_int());
-        Self(result.wrapping_sub(M * (over as u64)))
+        let mut val = result.wrapping_sub(M * (over as u64));
+        // For some reason, this `if` codeblock improves NTT runtime by ~10 % and
+        // Rescue prime calculations with up to 45 % for `hash_pair`. I think it has
+        // something to do with a compiler optimization but I actually don't
+        // understand why this speedup occurs.
+        if val > M - 1 {
+            val -= M;
+        }
+
+        Self(val)
     }
 }
 


### PR DESCRIPTION
This extra check speeds up Rescue Prime on my DELL XPS 16GB RAM with 50
%.

Executing `cargo criterion hash` gives me:

Before this commit:
hash_rp64_256 (random)  time:   [31.142 us 31.200 us 31.292 us]

After this commit:
hash_rp64_256 (random)  time:   [17.937 us 17.951 us 17.966 us]

My best guess for why this significant speedup happens is that the
multiplication in `add` can sometimes be avoided.