### PR TITLE
Enlarge exemption limit

### DIFF
--- a/air/src/air/context.rs
+++ b/air/src/air/context.rs
@@ -254,11 +254,11 @@ impl<B: StarkField> AirContext<B> {
             n > 0,
             "number of transition exemptions must be greater than zero"
         );
-        // exemptions which are for more than half the trace are probably a mistake
+        // exemptions which are for more than half the trace plus one are probably a mistake
         assert!(
-            n <= self.trace_len() / 2,
+            n <= self.trace_len() / 2 + 1,
             "number of transition exemptions cannot exceed {}, but was {}",
-            self.trace_len() / 2,
+            self.trace_len() / 2 + 1,
             n
         );
         // make sure the composition polynomial can be computed correctly with the specified


### PR DESCRIPTION
This (tiny) PR increases the transition constraint exemption limit in `AirContext` by one.

I believe that in some cases, the current limit may be a problem (for instance a trace where the 2^k rows are necessary, which then needs to be extended to the next power of two 2^{k+1}). In such cases, the current limit won't be sufficient, because the last evaluation frame to be checked on the proving side will overlap between the actual trace and the dummy values.