### PR TITLE
Custom doubling

### DIFF
--- a/math/benches/field.rs
+++ b/math/benches/field.rs
@@ -54,6 +54,11 @@ where
         bench.iter(|| black_box(x) + black_box(y))
     });
 
+    group.bench_function("double", |bench| {
+        let x = rand_value::<B>();
+        bench.iter(|| black_box(x).double())
+    });
+
     group.bench_function("sub", |bench| {
         let x = rand_value::<B>();
         let y = rand_value::<B>();
@@ -89,6 +94,11 @@ where
             bench.iter(|| black_box(x) + black_box(y))
         });
 
+        group.bench_function("quad/double", |bench| {
+            let x = rand_value::<QuadExtension<B>>();
+            bench.iter(|| black_box(x).double())
+        });
+
         group.bench_function("quad/sub", |bench| {
             let x = rand_value::<QuadExtension<B>>();
             let y = rand_value::<QuadExtension<B>>();
@@ -112,6 +122,11 @@ where
             let x = rand_value::<CubeExtension<B>>();
             let y = rand_value::<CubeExtension<B>>();
             bench.iter(|| black_box(x) + black_box(y))
+        });
+
+        group.bench_function("cube/double", |bench| {
+            let x = rand_value::<CubeExtension<B>>();
+            bench.iter(|| black_box(x).double())
         });
 
         group.bench_function("cube/sub", |bench| {

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -65,6 +65,11 @@ impl<B: ExtensibleField<3>> FieldElement for CubeExtension<B> {
     const ONE: Self = Self(B::ONE, B::ZERO, B::ZERO);
 
     #[inline]
+    fn double(self) -> Self {
+        Self(self.0.double(), self.1.double(), self.2.double())
+    }
+
+    #[inline]
     fn inv(self) -> Self {
         if self == Self::ZERO {
             return self;

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -65,6 +65,11 @@ impl<B: ExtensibleField<2>> FieldElement for QuadExtension<B> {
     const ONE: Self = Self(B::ONE, B::ZERO);
 
     #[inline]
+    fn double(self) -> Self {
+        Self(self.0.double(), self.1.double())
+    }
+
+    #[inline]
     fn inv(self) -> Self {
         if self == Self::ZERO {
             return self;

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -78,6 +78,13 @@ impl FieldElement for BaseElement {
     const ELEMENT_BYTES: usize = ELEMENT_BYTES;
     const IS_CANONICAL: bool = false;
 
+    #[inline]
+    fn double(self) -> Self {
+        let z = self.0 << 1;
+        let q = (z >> 62) * M;
+        Self(z - q)
+    }
+
     fn exp(self, power: Self::PositiveInteger) -> Self {
         let mut b = self;
 

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -73,6 +73,13 @@ impl FieldElement for BaseElement {
     const IS_CANONICAL: bool = false;
 
     #[inline]
+    fn double(self) -> Self {
+        let ret = (self.0 as u128) << 1;
+        let (result, over) = (ret as u64, (ret >> 64) as u64);
+        Self(result.wrapping_sub(M * (over as u64)))
+    }
+
+    #[inline]
     fn exp(self, power: Self::PositiveInteger) -> Self {
         let mut b = self;
 


### PR DESCRIPTION
This PR overrides the default `double()` method of the `FieldElement` trait for `f64`, `f62`, and related extensions. 
This yielded on my machine a speed-up of respectively 22.1% / 37.9% / 27.5% for `f64` simple/quad/cube and 7.3% / 7.2% / 4.2% for `f62` simple/quad/cube.
I haven't found a significant improvement on `f128` hence I left it untouched. I also added the `double()` operation to the field benchmarks for comparison with the `add` methods.