### PR TITLE
f64 exp ct

### DIFF
--- a/crypto/src/hash/rescue/rp64_256/mod.rs
+++ b/crypto/src/hash/rescue/rp64_256/mod.rs
@@ -328,9 +328,7 @@ impl Rp64_256 {
     #[inline(always)]
     fn apply_sbox(state: &mut [BaseElement; STATE_WIDTH]) {
         state.iter_mut().for_each(|v| {
-            let t2 = v.square();
-            let t4 = t2.square();
-            *v *= t2 * t4;
+            *v = v.exp7();
         });
     }
 

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -70,6 +70,16 @@ impl BaseElement {
     pub const fn inner(&self) -> u64 {
         self.0
     }
+
+    /// Computes an exponentiation to the power 7. This is useful for computing Rescue-Prime
+    /// S-Box over this field.
+    #[inline(always)]
+    pub fn exp7(self) -> Self {
+        let x2 = self.square();
+        let x4 = x2.square();
+        let x3 = x2 * self;
+        x3 * x4
+    }
 }
 
 impl FieldElement for BaseElement {

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -91,21 +91,17 @@ impl FieldElement for BaseElement {
 
     #[inline]
     fn exp(self, power: Self::PositiveInteger) -> Self {
-        let mut b = self;
-
-        if power == 0 {
-            return Self::ONE;
-        } else if b == Self::ZERO {
-            return Self::ZERO;
+        let mut b: Self;
+        let mut r = Self::ONE;
+        for i in (0..64).rev() {
+            r = r.square();
+            b = r;
+            b *= self;
+            // Constant-time branching
+            let mask = -(((power >> i) & 1 == 1) as i64) as u64;
+            r.0 ^= mask & (r.0 ^ b.0);
         }
 
-        let mut r = if power & 1 == 1 { b } else { Self::ONE };
-        for i in 1..64 - power.leading_zeros() {
-            b = b.square();
-            if (power >> i) & 1 == 1 {
-                r *= b;
-            }
-        }
         r
     }
 

--- a/math/src/field/f64/tests.rs
+++ b/math/src/field/f64/tests.rs
@@ -89,14 +89,17 @@ fn exp() {
     let a = BaseElement::ZERO;
     assert_eq!(a.exp(0), BaseElement::ONE);
     assert_eq!(a.exp(1), BaseElement::ZERO);
+    assert_eq!(a.exp7(), BaseElement::ZERO);
 
     let a = BaseElement::ONE;
     assert_eq!(a.exp(0), BaseElement::ONE);
     assert_eq!(a.exp(1), BaseElement::ONE);
     assert_eq!(a.exp(3), BaseElement::ONE);
+    assert_eq!(a.exp7(), BaseElement::ONE);
 
     let a: BaseElement = rand_value();
     assert_eq!(a.exp(3), a * a * a);
+    assert_eq!(a.exp(7), a.exp7());
 }
 
 #[test]


### PR DESCRIPTION
This PR makes f64 `exp()` method constant-time to match the module description, and add a helper method `exp7()` for Rescue-Prime S-Box.