### PR TITLE
Performance improvement in Matrix::interpolate_columns

### DIFF
--- a/prover/src/matrix.rs
+++ b/prover/src/matrix.rs
@@ -150,10 +150,14 @@ impl<E: FieldElement> Matrix<E> {
     ///   coefficients of a degree `num_rows - 1` polynomial.
     pub fn interpolate_columns(&self) -> Self {
         let inv_twiddles = fft::get_inv_twiddles::<E::BaseField>(self.num_rows());
-        // TODO: get ride of cloning by introducing another version of fft::interpolate_poly()
-        let mut result = self.clone();
-        iter_mut!(result.columns).for_each(|column| fft::interpolate_poly(column, &inv_twiddles));
-        result
+        let columns = iter!(self.columns)
+            .map(|evaluations| {
+                let mut column = evaluations.clone();
+                fft::interpolate_poly(&mut column, &inv_twiddles);
+                column
+            })
+            .collect();
+        Self { columns }
     }
 
     /// Interpolates columns of the matrix into polynomials in coefficient form and returns the


### PR DESCRIPTION
Instead of cloning the entire matrix with a single .clone(), which will clone each column vector sequentially, do each column clone
inside the parallelized loop. This has a significant performance impact when run with concurrency.

Running the [stark-bench](https://github.com/bobbinth/stark-bench) benchmarks on a 64-core AWS machine (c7g.16xlarge) leads to a ~57% improvement in the interpolation step. UPDATE: The parameters I used to obtain this result were `stark-bench -c 255 -n 23 -b 2`.