### PR TITLE
Update versions of all crates to v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.4.1 (2022-10-24)
+* Increased transition constraint exemption limit by 1.
+* Implemented custom doubling for `f64` and `f62` field.
+* Moved `f64` field arithmetic to Montgomery form (constant time).
+* Updated MDS matrix and related-multiplication routine for `Rp64_256` hash function.
+* Improved performance of `Matrix::interpolate_columns` function.
+* Added ability to "unbatch" a `BatchMerkleProof` (via `BatchMerkleProof::into_paths()` method).
+* Changed visibility of FRI utils (made them public).
+* Added support for FRI folding factor of 2 (in addition to 4, 8, and 16).
+
 ## 0.4.0 (2022-04-29)
 * Added support for Randomized AIR (with example).
 * Added support for custom number of transition constraint exemptions.

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-air"
-version = "0.4.0"
+version = "0.4.1"
 description = "AIR components for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-air/0.4.0"
+documentation = "https://docs.rs/winter-air/0.4.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "arithmetization", "air"]
 edition = "2021"
@@ -20,13 +20,13 @@ default = ["std"]
 std = ["crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-crypto = { version = "0.4", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.4", path = "../fri", package = "winter-fri", default-features = false }
-math = { version = "0.4", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.4", path = "../utils/core", package = "winter-utils", default-features = false }
+crypto = { version = "0.4.1", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.4.1", path = "../fri", package = "winter-fri", default-features = false }
+math = { version = "0.4.1", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.4.1", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
-rand-utils = { version = "0.4", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.4.1", path = "../utils/rand", package = "winter-rand-utils" }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/air/src/air/trace_info.rs
+++ b/air/src/air/trace_info.rs
@@ -215,7 +215,7 @@ impl TraceLayout {
                 was_zero_width = true;
             }
             assert!(
-                num_rand_elements <= TraceInfo::MAX_RAND_SEGMENT_ELEMENTS as usize,
+                num_rand_elements <= TraceInfo::MAX_RAND_SEGMENT_ELEMENTS,
                 "number of random elements required by a segment cannot exceed {}, but was {}",
                 TraceInfo::MAX_RAND_SEGMENT_ELEMENTS,
                 num_rand_elements

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-crypto"
-version = "0.4.0"
+version = "0.4.1"
 description = "Cryptographic library for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-crypto/0.4.0"
+documentation = "https://docs.rs/winter-crypto/0.4.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "merkle-tree", "hash"]
 edition = "2021"
@@ -31,11 +31,11 @@ std = ["blake3/std", "math/std", "sha3/std", "utils/std"]
 
 [dependencies]
 blake3 = { version = "1.0", default-features = false }
-math = { version = "0.4", path = "../math", package = "winter-math", default-features = false }
+math = { version = "0.4.1", path = "../math", package = "winter-math", default-features = false }
 sha3 = { version = "0.10", default-features = false }
-utils = { version = "0.4", path = "../utils/core", package = "winter-utils", default-features = false }
+utils = { version = "0.4.1", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 proptest = "1.0"
-rand-utils = { version = "0.4", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.4.1", path = "../utils/rand", package = "winter-rand-utils" }

--- a/crypto/src/random/mod.rs
+++ b/crypto/src/random/mod.rs
@@ -183,7 +183,7 @@ impl<B: StarkField, H: Hasher> RandomCoin<B, H> {
         for _ in 0..1000 {
             // get the next pseudo-random value and take the first ELEMENT_BYTES from it
             let value = self.next();
-            let bytes = &value.as_bytes()[..E::ELEMENT_BYTES as usize];
+            let bytes = &value.as_bytes()[..E::ELEMENT_BYTES];
 
             // check if the bytes can be converted into a valid field element; if they can,
             // return; otherwise try again

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.4.0"
+version = "0.4.1"
 description = "Examples of using Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
@@ -26,9 +26,9 @@ default = ["std"]
 std = ["hex/std", "winterfell/std", "core-utils/std", "rand-utils"]
 
 [dependencies]
-winterfell = { version="0.4", path = "../winterfell", default-features = false }
-core-utils = { version = "0.4", path = "../utils/core", package = "winter-utils", default-features = false }
-rand-utils = { version = "0.4", path = "../utils/rand", package = "winter-rand-utils", optional = true }
+winterfell = { version="0.4.1", path = "../winterfell", default-features = false }
+core-utils = { version = "0.4.1", path = "../utils/core", package = "winter-utils", default-features = false }
+rand-utils = { version = "0.4.1", path = "../utils/rand", package = "winter-rand-utils", optional = true }
 hex = { version = "0.4", optional = true }
 log = { version = "0.4", default-features = false }
 blake3 = { version = "1.0", default-features = false }
@@ -36,7 +36,7 @@ env_logger = { version = "0.9", default-features = false }
 structopt = { version = "0.3", default-features = false }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 
 [[bench]]
 name = "fibonacci"

--- a/examples/src/rescue_raps/custom_trace_table.rs
+++ b/examples/src/rescue_raps/custom_trace_table.rs
@@ -85,7 +85,7 @@ impl<B: StarkField> RapTraceTable<B> {
             "execution trace length must be a power of 2"
         );
         assert!(
-            log2(length) as u32 <= B::TWO_ADICITY,
+            log2(length) <= B::TWO_ADICITY,
             "execution trace length cannot exceed 2^{} steps, but was 2^{}",
             B::TWO_ADICITY,
             log2(length)

--- a/examples/src/rescue_raps/mod.rs
+++ b/examples/src/rescue_raps/mod.rs
@@ -59,7 +59,7 @@ impl RescueRapsExample {
         );
         assert!(chain_length > 2, "chain length must be at least 4");
 
-        let mut seeds = vec![[BaseElement::ZERO; 2]; chain_length as usize];
+        let mut seeds = vec![[BaseElement::ZERO; 2]; chain_length];
         for internal_seed in seeds.iter_mut() {
             *internal_seed = rand_array();
         }

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-fri"
-version = "0.4.0"
+version = "0.4.1"
 description = "Implementation of FRI protocol for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-fri/0.4.0"
+documentation = "https://docs.rs/winter-fri/0.4.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "polynomial", "commitments"]
 edition = "2021"
@@ -29,10 +29,10 @@ default = ["std"]
 std = ["crypto/std", "math/std", "utils/std"]
 
 [dependencies]
-crypto = { version = "0.4", path = "../crypto", package = "winter-crypto", default-features = false }
-math = { version = "0.4", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.4", path = "../utils/core", package = "winter-utils", default-features = false }
+crypto = { version = "0.4.1", path = "../crypto", package = "winter-crypto", default-features = false }
+math = { version = "0.4.1", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.4.1", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
-criterion = "0.3"
-rand-utils = { version = "0.4", path = "../utils/rand", package = "winter-rand-utils" }
+criterion = "0.4"
+rand-utils = { version = "0.4.1", path = "../utils/rand", package = "winter-rand-utils" }

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-math"
-version = "0.4.0"
+version = "0.4.1"
 description = "Math library for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-math/0.4.0"
+documentation = "https://docs.rs/winter-math/0.4.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "finite-fields", "polynomials", "fft"]
 edition = "2021"
@@ -33,10 +33,10 @@ default = ["std"]
 std = ["utils/std"]
 
 [dependencies]
-utils = { version = "0.4", path = "../utils/core", package = "winter-utils", default-features = false }
+utils = { version = "0.4.1", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 num-bigint = "0.4"
 proptest = "1.0"
 rand-utils = { version = "0.4", path = "../utils/rand", package = "winter-rand-utils" }

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -96,7 +96,7 @@ impl FieldElement for BaseElement {
     fn double(self) -> Self {
         let ret = (self.0 as u128) << 1;
         let (result, over) = (ret as u64, (ret >> 64) as u64);
-        Self(result.wrapping_sub(M * (over as u64)))
+        Self(result.wrapping_sub(M * over))
     }
 
     #[inline]

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-prover"
-version = "0.4.0"
+version = "0.4.1"
 description = "Winterfell STARK prover"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-prover/0.4.0"
+documentation = "https://docs.rs/winter-prover/0.4.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "prover"]
 edition = "2021"
@@ -21,12 +21,12 @@ default = ["std"]
 std = ["air/std", "crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-air = { version = "0.4", path = "../air", package = "winter-air", default-features = false }
-crypto = { version = "0.4", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.4", path = '../fri', package = "winter-fri", default-features = false }
+air = { version = "0.4.1", path = "../air", package = "winter-air", default-features = false }
+crypto = { version = "0.4.1", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.4.1", path = '../fri', package = "winter-fri", default-features = false }
 log = { version = "0.4", default-features = false }
-math = { version = "0.4", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.4", path = "../utils/core", package = "winter-utils", default-features = false }
+math = { version = "0.4.1", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.4.1", path = "../utils/core", package = "winter-utils", default-features = false }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/prover/src/trace/trace_table.rs
+++ b/prover/src/trace/trace_table.rs
@@ -117,7 +117,7 @@ impl<B: StarkField> TraceTable<B> {
             "execution trace length must be a power of 2"
         );
         assert!(
-            log2(length) as u32 <= B::TWO_ADICITY,
+            log2(length) <= B::TWO_ADICITY,
             "execution trace length cannot exceed 2^{} steps, but was 2^{}",
             B::TWO_ADICITY,
             log2(length)
@@ -168,7 +168,7 @@ impl<B: StarkField> TraceTable<B> {
             "execution trace length must be a power of 2"
         );
         assert!(
-            log2(trace_length) as u32 <= B::TWO_ADICITY,
+            log2(trace_length) <= B::TWO_ADICITY,
             "execution trace length cannot exceed 2^{} steps, but was 2^{}",
             B::TWO_ADICITY,
             log2(trace_length)

--- a/utils/core/Cargo.toml
+++ b/utils/core/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-utils"
-version = "0.4.0"
+version = "0.4.1"
 description = "Utilities for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-utils/0.4.0"
+documentation = "https://docs.rs/winter-utils/0.4.1"
 categories = ["cryptography", "no-std"]
 keywords = ["serialization", "transmute"]
 edition = "2021"

--- a/utils/core/src/lib.rs
+++ b/utils/core/src/lib.rs
@@ -301,7 +301,7 @@ impl<'a> ByteReader for SliceReader<'a> {
     }
 
     fn read_u8_vec(&mut self, len: usize) -> Result<Vec<u8>, DeserializationError> {
-        let end_pos = self.pos + len as usize;
+        let end_pos = self.pos + len;
         if end_pos > self.source.len() {
             return Err(DeserializationError::UnexpectedEOF);
         }

--- a/utils/rand/Cargo.toml
+++ b/utils/rand/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-rand-utils"
-version = "0.4.0"
+version = "0.4.1"
 description = "Random value generation utilities for Winterfell crates"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-rand-utils/0.4.0"
+documentation = "https://docs.rs/winter-rand-utils/0.4.1"
 categories = ["cryptography"]
 keywords = ["rand"]
 edition = "2021"
@@ -16,7 +16,7 @@ rust-version = "1.60"
 bench = false
 
 [dependencies]
-utils = { version = "0.4", path = "../core", package = "winter-utils" }
+utils = { version = "0.4.1", path = "../core", package = "winter-utils" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rand =  { version = "0.8" }

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-verifier"
-version = "0.4.0"
+version = "0.4.1"
 description = "Winterfell STARK verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-verifier/0.3.0"
+documentation = "https://docs.rs/winter-verifier/0.4.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "verifier"]
 edition = "2021"
@@ -20,11 +20,11 @@ default = ["std"]
 std = ["air/std", "crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-air = { version = "0.4", path = "../air", package = "winter-air", default-features = false }
-crypto = { version = "0.4", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.4", path = "../fri", package = "winter-fri", default-features = false }
-math = { version = "0.4", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.4", path = "../utils/core", package = "winter-utils", default-features = false }
+air = { version = "0.4.1", path = "../air", package = "winter-air", default-features = false }
+crypto = { version = "0.4.1", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.4.1", path = "../fri", package = "winter-fri", default-features = false }
+math = { version = "0.4.1", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.4.1", path = "../utils/core", package = "winter-utils", default-features = false }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/winterfell/Cargo.toml
+++ b/winterfell/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winterfell"
-version = "0.4.0"
+version = "0.4.1"
 description = "Winterfell STARK prover and verifier"
 authors = ["winterfell contributors"]
 readme = "../README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winterfell/0.4.0"
+documentation = "https://docs.rs/winterfell/0.4.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "prover", "verifier"]
 edition = "2021"
@@ -21,8 +21,8 @@ default = ["std"]
 std = ["prover/std", "verifier/std"]
 
 [dependencies]
-prover = { version = "0.4", path = "../prover", package = "winter-prover", default-features = false }
-verifier = { version = "0.4", path = "../verifier", package = "winter-verifier", default-features = false }
+prover = { version = "0.4.1", path = "../prover", package = "winter-prover", default-features = false }
+verifier = { version = "0.4.1", path = "../verifier", package = "winter-verifier", default-features = false }
 
 # Allow math in docs
 [package.metadata.docs.rs]


### PR DESCRIPTION
This PR updates versions of all crates to v0.4.1 in preparation of v0.4.1 release. Changelog has also been updated to reflect all changes since v0.4 release.