### PR TITLE
Re-export btree_map and btree_set modules

### DIFF
--- a/utils/core/src/collections.rs
+++ b/utils/core/src/collections.rs
@@ -10,13 +10,13 @@
 //! standard library.
 
 #[cfg(not(feature = "std"))]
-pub use alloc::collections::{BTreeMap, BTreeSet};
+pub use alloc::collections::{btree_map, btree_set, BTreeMap, BTreeSet};
 
 #[cfg(not(feature = "std"))]
 pub use alloc::vec::{self as vec, Vec};
 
 #[cfg(feature = "std")]
-pub use std::collections::{BTreeMap, BTreeSet};
+pub use std::collections::{btree_map, btree_set, BTreeMap, BTreeSet};
 
 #[cfg(feature = "std")]
 pub use std::vec::{self as vec, Vec};


### PR DESCRIPTION
This PR re-exports `btree_map` and `btree_set` modules.  This allows downstream consumers to leverage types such as `btree_map::Entry`, `btree_map::Values`.  This is useful for [this](https://github.com/0xPolygonMiden/miden-vm/issues/904) `miden-vm` PR where we want to use the `Entry` api and as such need access to the [`Entry`](https://doc.rust-lang.org/stable/std/collections/btree_map/enum.Entry.html) enum.  Additionally we also need [`btree_map::Values`](https://doc.rust-lang.org/stable/std/collections/btree_map/struct.Values.html#). 