### PR TITLE
Implement `StarkProof::new_dummy()`

### DIFF
--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -181,7 +181,7 @@ impl StarkProof {
         Ok(proof)
     }
 
-    /// Creates a dummy `StarkProof` for use in tests
+    /// Creates a dummy `StarkProof` for use in tests.
     pub fn new_dummy() -> Self {
         use crate::FieldExtension;
         use crypto::hashers::Blake3_192 as DummyHasher;

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -67,7 +67,7 @@ impl FriProof {
         }
     }
 
-    /// Creates a dummy `FriProof` for use in tests
+    /// Creates a dummy `FriProof` for use in tests.
     pub fn new_dummy() -> Self {
         Self {
             layers: Vec::new(),


### PR DESCRIPTION
It is currently impossible to create a dummy `StarkProof` object for use in tests of crates of depend on `winterfell`. This PR solves this problem by exposing a function `new_dummy()`.