### PR TITLE
fix: use POSIX-compatible array syntax in publish-crates.sh

### DIFF
--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -15,19 +15,8 @@ git pull origin main
 
 # Publish
 echo "Publishing crates..."
-crates=(
-winter-utils
-winter-rand-utils
-winter-maybe-async
-winter-math
-winter-crypto
-winter-fri
-winter-air
-winter-prover
-winter-verifier
-winterfell
-)
-for crate in ${crates[@]}; do
+crates="winter-utils winter-rand-utils winter-maybe-async winter-math winter-crypto winter-fri winter-air winter-prover winter-verifier winterfell"
+for crate in $crates; do
     echo "Publishing $crate..."
     cargo publish -p "$crate" $@
 done


### PR DESCRIPTION
Replaced Bash-style array declaration with a POSIX-compliant space-separated string and updated the loop accordingly. This ensures the script works correctly with /bin/sh and improves portability across different Unix environments. No other changes were made.