### PR TITLE
fix: prevent panic in rand_vector when `n == 0`

### DIFF
--- a/utils/rand/src/lib.rs
+++ b/utils/rand/src/lib.rs
@@ -44,6 +44,9 @@ mod internal {
     /// * A valid value requires at over 32 bytes.
     /// * A valid value could not be generated after 1000 tries.
     pub fn rand_vector<R: Randomizable>(n: usize) -> Vec<R> {
+        if n == 0 {
+            return Vec::new();
+        }
         let mut result = Vec::with_capacity(n);
         let seed = rand::rng().random::<[u8; 32]>();
         let mut g = StdRng::from_seed(seed);


### PR DESCRIPTION
When called with `n == 0` (aka asked to produce a vector of random numbers of size 0)
`rand_vector` falls through to its final panic.

This special-cases n == 0 to return an empy vector instead.

This fixes https://github.com/0xMiden/miden-vm/issues/1314