### PR TITLE
feat: Implement Serializable/Deserializable for hashbrown structures

### DIFF
--- a/utils/core/Cargo.toml
+++ b/utils/core/Cargo.toml
@@ -21,6 +21,7 @@ default = ["std"]
 std = []
 
 [dependencies]
+hashbrown = { default-features = false, optional = true, version = "0.15" }
 rayon = { version = "1.10", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
`hashbrown` allows the usage of hash-based structures in `no_std` scenarios.

It is not known why `winter-utils` doesn't implement Serializable/Deserializable for the hash-based structures provided by the standard library (out-of-order insertion?). `serde` does and it is valid use-case.