### PR TITLE
fix: correct typos in code comments

### DIFF
--- a/fri/src/prover/mod.rs
+++ b/fri/src/prover/mod.rs
@@ -202,7 +202,7 @@ where
     fn build_layer<const N: usize>(&mut self, channel: &mut C, evaluations: &mut Vec<E>) {
         // commit to the evaluations at the current layer; we do this by first transposing the
         // evaluations into a matrix of N columns, then hashing each row into a digest, and finally
-        // commiting to vector of these digests; we do this so that we could de-commit to N values
+        // committing to vector of these digests; we do this so that we could de-commit to N values
         // with a single opening proof.
         let transposed_evaluations = transpose_slice(evaluations);
         let evaluation_vector_commitment =

--- a/prover/src/constraints/commitment/mod.rs
+++ b/prover/src/constraints/commitment/mod.rs
@@ -25,7 +25,7 @@ pub trait ConstraintCommitment<E: FieldElement> {
     /// The hash function used for hashing the rows of trace segment LDEs.
     type HashFn: ElementHasher<BaseField = E::BaseField>;
 
-    /// The vector commitment scheme used for commiting to the trace.
+    /// The vector commitment scheme used for committing to the trace.
     type VC: VectorCommitment<Self::HashFn>;
 
     /// Returns the commitment.

--- a/prover/src/matrix/row_matrix.rs
+++ b/prover/src/matrix/row_matrix.rs
@@ -310,7 +310,7 @@ fn transpose<B: StarkField, const N: usize>(mut segments: Vec<Segment<B, N>>) ->
     // TODO: investigate transposing in-place
     let mut result = unsafe { uninit_vector::<[B; N]>(result_len) };
 
-    // determine number of batches in which transposition will be preformed; if `concurrent`
+    // determine number of batches in which transposition will be performed; if `concurrent`
     // feature is not enabled, the number of batches will always be 1
     let num_batches = get_num_batches(result_len);
     let rows_per_batch = num_rows / num_batches;

--- a/prover/src/trace/trace_lde/default/mod.rs
+++ b/prover/src/trace/trace_lde/default/mod.rs
@@ -195,7 +195,7 @@ where
     }
 
     /// Returns trace table rows at the specified positions along with an opening proof to these
-    /// rows againt the already computed commitment.
+    /// rows against the already computed commitment.
     fn query(&self, positions: &[usize]) -> Vec<Queries> {
         // build queries for the main trace segment
         let mut result = vec![build_segment_queries::<E::BaseField, H, V>(

--- a/prover/src/trace/trace_lde/mod.rs
+++ b/prover/src/trace/trace_lde/mod.rs
@@ -27,7 +27,7 @@ pub trait TraceLde<E: FieldElement>: Sync {
     /// The hash function used for hashing the rows of trace segment LDEs.
     type HashFn: ElementHasher<BaseField = E::BaseField>;
 
-    /// The vector commitment scheme used for commiting to the trace.
+    /// The vector commitment scheme used for committing to the trace.
     type VC: VectorCommitment<Self::HashFn>;
 
     /// Returns the commitment to the low-degree extension of the main trace segment.


### PR DESCRIPTION


## Description:

This PR fixes minor spelling errors in code comments across multiple files:

### Changes:
- **`prover/src/matrix/row_matrix.rs`**: `preformed` → `performed`
- **`prover/src/trace/trace_lde/default/mod.rs`**: `againt` → `against`  
- **`prover/src/trace/trace_lde/mod.rs`**: `commiting` → `committing`

