### PR TITLE
Add logging for openning phase of proof generation

### DIFF
--- a/prover/src/constraints/composition_poly.rs
+++ b/prover/src/constraints/composition_poly.rs
@@ -7,6 +7,7 @@ use alloc::vec::Vec;
 
 use air::proof::QuotientOodFrame;
 use math::{fft, polynom::degree_of, FieldElement, StarkField};
+use tracing::instrument;
 
 use super::{ColMatrix, StarkDomain};
 
@@ -98,6 +99,7 @@ impl<E: FieldElement> CompositionPoly<E> {
     }
 
     /// Returns evaluations of all composition polynomial columns at points `z` and `g * z`.
+    #[instrument(skip_all)]
     pub fn get_ood_frame(&self, z: E) -> QuotientOodFrame<E> {
         let log_trace_len = self.column_len().ilog2();
         let g = E::from(E::BaseField::get_root_of_unity(log_trace_len));

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -383,6 +383,7 @@ pub trait Prover {
             .commit_to_constraint_evaluations(&air, composition_poly_trace, &domain, &mut channel));
 
         // 4 ----- build DEEP composition polynomial ----------------------------------------------
+        let opening_span = info_span!("opening").entered();
         let deep_composition_poly = {
             let span = info_span!("build_deep_composition_poly").entered();
             // draw an out-of-domain point z. Depending on the type of E, the point is drawn either
@@ -460,6 +461,7 @@ pub trait Prover {
             drop(span);
             query_positions
         };
+        drop(opening_span);
 
         // 8 ----- build proof object -------------------------------------------------------------
         let proof = {

--- a/prover/src/matrix/col_matrix.rs
+++ b/prover/src/matrix/col_matrix.rs
@@ -8,6 +8,7 @@ use core::{iter::FusedIterator, slice};
 
 use crypto::{ElementHasher, VectorCommitment};
 use math::{fft, polynom, FieldElement};
+use tracing::info_span;
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;
 use utils::{batch_iter_mut, iter, iter_mut, uninit_vector};
@@ -246,7 +247,9 @@ impl<E: FieldElement> ColMatrix<E> {
     where
         F: FieldElement + From<E>,
     {
-        iter!(self.columns).map(|p| polynom::eval(p, x)).collect()
+        let dim = (self.num_cols(), self.num_rows());
+        info_span!("compute opened values with Horner evaluation", ?dim)
+            .in_scope(|| iter!(self.columns).map(|p| polynom::eval(p, x)).collect())
     }
 
     // COMMITMENTS

--- a/prover/src/trace/poly_table.rs
+++ b/prover/src/trace/poly_table.rs
@@ -7,6 +7,7 @@ use alloc::vec::Vec;
 
 use air::proof::TraceOodFrame;
 use math::{FieldElement, StarkField};
+use tracing::instrument;
 
 use crate::{matrix::ColumnIter, ColMatrix};
 
@@ -65,6 +66,7 @@ impl<E: FieldElement> TracePolyTable<E> {
 
     /// Returns an out-of-domain evaluation frame constructed by evaluating trace polynomials for
     /// all columns at points z and z * g, where g is the generator of the trace domain.
+    #[instrument(skip_all)]
     pub fn get_ood_frame(&self, z: E) -> TraceOodFrame<E> {
         let log_trace_len = self.poly_size().ilog2();
         let g = E::from(E::BaseField::get_root_of_unity(log_trace_len));


### PR DESCRIPTION
Includes also logging for computing the opening values of each committed polynomial i.e., OOD evaluations.