### PR TITLE
Change VerifierChannel:read_trace_commitments() to return (H::Digest, Option<H::Digest>)

### DIFF
--- a/verifier/src/channel.rs
+++ b/verifier/src/channel.rs
@@ -155,10 +155,16 @@ where
 
     /// Returns execution trace commitments sent by the prover.
     ///
-    /// For computations requiring multiple trace segment, the returned slice will contain a
-    /// commitment for each trace segment.
-    pub fn read_trace_commitments(&self) -> &[H::Digest] {
-        &self.trace_commitments
+    /// Returns a tuple containing the main trace commitment and an optional auxiliary trace
+    /// commitment (present only for multi-segment traces).
+    pub fn read_trace_commitments(&self) -> (H::Digest, Option<H::Digest>) {
+        let main = self.trace_commitments[0];
+        let aux = if self.trace_commitments.len() > 1 {
+            Some(self.trace_commitments[1])
+        } else {
+            None
+        };
+        (main, aux)
     }
 
     /// Returns constraint evaluation commitment sent by the prover.

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -167,12 +167,10 @@ where
     // used to draw random elements needed to construct the next trace segment. The last trace
     // commitment is used to draw a set of random coefficients which the prover uses to compute
     // constraint composition polynomial.
-    const MAIN_TRACE_IDX: usize = 0;
-    const AUX_TRACE_IDX: usize = 1;
-    let trace_commitments = channel.read_trace_commitments();
+    let (main_trace_commitment, aux_trace_commitment) = channel.read_trace_commitments();
 
     // reseed the coin with the commitment to the main trace segment
-    public_coin.reseed(trace_commitments[MAIN_TRACE_IDX]);
+    public_coin.reseed(main_trace_commitment);
 
     // process auxiliary trace segments (if any), to build a set of random elements for each segment
     let aux_trace_rand_elements = if air.trace_info().is_multi_segment() {
@@ -180,7 +178,7 @@ where
             .get_aux_rand_elements(&mut public_coin)
             .expect("failed to generate the random elements needed to build the auxiliary trace");
 
-        public_coin.reseed(trace_commitments[AUX_TRACE_IDX]);
+        public_coin.reseed(aux_trace_commitment.expect("missing auxiliary trace commitment"));
 
         Some(aux_rand_elements)
     } else {


### PR DESCRIPTION
I updated read_trace_commitments to return (H::Digest, Option<H::Digest>), and adjusted the verifier to destructure it and reseed using the main commitment and, when applicable, the auxiliary commitment.